### PR TITLE
Targetting Haswell only makes sense on CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,3 @@
 [build]
-rustflags = ["-Ctarget-cpu=haswell"]
-rustdocflags = ["-Ctarget-cpu=haswell"]
+rustflags = ["-Ctarget-cpu=native"]
+rustdocflags = ["-Ctarget-cpu=native"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,26 +29,35 @@ jobs:
 
       - name: Run tests
         run: cargo test --release --all-features
+        env:
+          RUSTFLAGS: -Ctarget-cpu=haswell
+          RUSTDOCFLAGS: -Ctarget-cpu=haswell
 
       - name: Run tests w/ AVX-512F enabled
         run: cargo test --release --all-features
         if: ${{ steps.avx512f.outcome == 'success' }}
         env:
-          RUSTFLAGS: -Ctarget-feature=+avx512f
-          RUSTDOCFLAGS: -Ctarget-feature=+avx512f
+          RUSTFLAGS: -Ctarget-cpu=haswell -Ctarget-feature=+avx512f
+          RUSTDOCFLAGS: -Ctarget-cpu=haswell -Ctarget-feature=+avx512f
 
       - name: Run tests (--no-default-features)
         run: cargo test --release --no-default-features
+        env:
+          RUSTFLAGS: -Ctarget-cpu=haswell
+          RUSTDOCFLAGS: -Ctarget-cpu=haswell
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -Dwarnings
+        env:
+          RUSTFLAGS: -Ctarget-cpu=haswell
+          RUSTDOCFLAGS: -Ctarget-cpu=haswell
 
       - name: Clippy w/ AVX-512F enabled
         run: cargo clippy --all-targets --all-features -- -Dwarnings
         if: ${{ steps.avx512f.outcome == 'success' }}
         env:
-          RUSTFLAGS: -Ctarget-feature=+avx512f
-          RUSTDOCFLAGS: -Ctarget-feature=+avx512f
+          RUSTFLAGS: -Ctarget-cpu=haswell -Ctarget-feature=+avx512f
+          RUSTDOCFLAGS: -Ctarget-cpu=haswell -Ctarget-feature=+avx512f
 
       - name: Check format
         run: cargo fmt -- --check


### PR DESCRIPTION
`haswell` is specified instead of `native` for testing with and without AVX512F.