### PR TITLE
Workaround for Clippy crashing since version `clippy 0.1.52 (98f8cce6…

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-02-25


### PR DESCRIPTION
… 2021-02-25)`

https://github.com/rust-lang/rust-clippy/issues/6855 seems relevant.