### PR TITLE
Implement (de)serialization for Interval structs & enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ gmp = ["gmp-mpfr-sys", "nom", "rug"]
 
 [dependencies]
 cfg-if = "1.0"
+serde = { version = "1.0.0", features = ["derive"], optional = true }
 
 [dependencies.gmp-mpfr-sys]
 version = "1.4"


### PR DESCRIPTION
This PR implements, as an _optional feature_, (de)serialization for Interval structs & enums using serde.