### PR TITLE
Extend arithmetic operator traits over refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ gmp = ["gmp-mpfr-sys", "nom", "rug"]
 
 [dependencies]
 cfg-if = "1.0"
+forward_ref = "1.0.0"
 
 [dependencies.gmp-mpfr-sys]
 version = "1.4"

--- a/src/absmax.rs
+++ b/src/absmax.rs
@@ -6,6 +6,7 @@ impl Interval {
     /// | Domain | Range     |
     /// | ------ | --------- |
     /// | $\R$   | $\[0, ∞)$ |
+    #[must_use]
     pub fn abs(self) -> Self {
         use IntervalClass::*;
         match self.classify() {
@@ -32,6 +33,7 @@ impl Interval {
     /// | Domain | Range |
     /// | ------ | ----- |
     /// | $\R^2$ | $\R$  |
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         if HAS_MAXIMUM {
             // [max(a, c), max(b, d)] = [-max(a, c); max(b, d)] = [min(-a, -c); max(b, d)]
@@ -58,6 +60,7 @@ impl Interval {
     /// | Domain | Range |
     /// | ------ | ----- |
     /// | $\R^2$ | $\R$  |
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         if HAS_MAXIMUM {
             // [min(a, c), min(b, d)] = [-min(a, c); min(b, d)] = [max(-a, -c); min(b, d)]
@@ -84,6 +87,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::abs`].
     ///
     /// A NaI is returned if `self` is NaI.
+    #[must_use]
     pub fn abs(self) -> Self {
         if self.is_nai() {
             return self;
@@ -95,6 +99,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::max`].
     ///
     /// A NaI is returned if `self` or `rhs` is NaI.
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         if self.is_nai() {
             return self;
@@ -106,6 +111,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::min`].
     ///
     /// A NaI is returned if `self` or `rhs` is NaI.
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         if self.is_nai() {
             return self;

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -1,5 +1,6 @@
 use crate::{classify::*, interval::*, simd::*};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use forward_ref::*;
 
 impl Neg for Interval {
     type Output = Self;
@@ -12,6 +13,8 @@ impl Neg for Interval {
     }
 }
 
+forward_ref_unop!(impl Neg, neg for Interval);
+
 impl Add for Interval {
     type Output = Self;
 
@@ -23,6 +26,8 @@ impl Add for Interval {
     }
 }
 
+forward_ref_binop!(impl Add, add for Interval, Interval);
+
 impl Sub for Interval {
     type Output = Self;
 
@@ -33,6 +38,8 @@ impl Sub for Interval {
         Self { rep: add_ru(x, y) }
     }
 }
+
+forward_ref_binop!(impl Sub, sub for Interval, Interval);
 
 impl Mul for Interval {
     type Output = Self;
@@ -125,6 +132,8 @@ impl Mul for Interval {
         }
     }
 }
+
+forward_ref_binop!(impl Mul, mul for Interval, Interval);
 
 impl Div for Interval {
     type Output = Self;
@@ -223,6 +232,8 @@ impl Div for Interval {
     }
 }
 
+forward_ref_binop!(impl Div, div for Interval, Interval);
+
 impl Neg for DecInterval {
     type Output = Self;
 
@@ -234,6 +245,8 @@ impl Neg for DecInterval {
         Self::set_dec(-self.x, self.d)
     }
 }
+
+forward_ref_unop!(impl Neg, neg for DecInterval);
 
 impl Add for DecInterval {
     type Output = Self;
@@ -247,6 +260,8 @@ impl Add for DecInterval {
     }
 }
 
+forward_ref_binop!(impl Add, add for DecInterval, DecInterval);
+
 impl Sub for DecInterval {
     type Output = Self;
 
@@ -259,6 +274,8 @@ impl Sub for DecInterval {
     }
 }
 
+forward_ref_binop!(impl Sub, sub for DecInterval, DecInterval);
+
 impl Mul for DecInterval {
     type Output = Self;
 
@@ -270,6 +287,8 @@ impl Mul for DecInterval {
         Self::set_dec(self.x * rhs.x, self.d.min(rhs.d))
     }
 }
+
+forward_ref_binop!(impl Mul, mul for DecInterval, DecInterval);
 
 impl Div for DecInterval {
     type Output = Self;
@@ -288,6 +307,8 @@ impl Div for DecInterval {
     }
 }
 
+forward_ref_binop!(impl Div, div for DecInterval, DecInterval);
+
 macro_rules! impl_op_assign {
     ($OpAssign:ident, $op_assign:ident, $op:ident) => {
         impl $OpAssign for Interval {
@@ -296,11 +317,17 @@ macro_rules! impl_op_assign {
             }
         }
 
+        forward_ref_op_assign!(impl $OpAssign, $op_assign for Interval,
+                               Interval);
+
         impl $OpAssign for DecInterval {
             fn $op_assign(&mut self, rhs: Self) {
                 *self = self.$op(rhs);
             }
         }
+
+        forward_ref_op_assign!(impl $OpAssign, $op_assign for DecInterval,
+                               DecInterval);
     };
 }
 

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -10,6 +10,7 @@ impl Interval {
     /// | $\R^3$ | $\R$  |
     // Almost a copy-paste of mul. Additions/modifications are indicated with "// *".
     #[allow(clippy::many_single_char_names)]
+    #[must_use]
     pub fn mul_add(self, rhs: Self, addend: Self) -> Self {
         if addend.is_empty() {
             return Self::EMPTY; // *
@@ -98,6 +99,7 @@ impl Interval {
     /// | Domain        | Range         |
     /// | ------------- | ------------- |
     /// | $\R ∖ \set 0$ | $\R ∖ \set 0$ |
+    #[must_use]
     pub fn recip(self) -> Self {
         use IntervalClass::*;
         match self.classify() {
@@ -139,6 +141,7 @@ impl Interval {
     /// | Domain | Range     |
     /// | ------ | --------- |
     /// | $\R$   | $\[0, ∞)$ |
+    #[must_use]
     pub fn sqr(self) -> Self {
         use IntervalClass::*;
         match self.classify() {
@@ -173,6 +176,7 @@ impl Interval {
     /// | Domain    | Range     |
     /// | --------- | --------- |
     /// | $\[0, ∞)$ | $\[0, ∞)$ |
+    #[must_use]
     pub fn sqrt(self) -> Self {
         if self.is_empty() {
             return Self::EMPTY;
@@ -195,6 +199,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::mul_add`].
     ///
     /// A NaI is returned if `self`, `rhs` or `addend` is NaI.
+    #[must_use]
     pub fn mul_add(self, rhs: Self, addend: Self) -> Self {
         if self.is_nai() || rhs.is_nai() || addend.is_nai() {
             return Self::NAI;
@@ -209,6 +214,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::recip`].
     ///
     /// A NaI is returned if `self` is NaI.
+    #[must_use]
     pub fn recip(self) -> Self {
         if self.is_nai() {
             return self;
@@ -225,6 +231,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::sqr`].
     ///
     /// A NaI is returned if `self` is NaI.
+    #[must_use]
     pub fn sqr(self) -> Self {
         if self.is_nai() {
             return self;
@@ -236,6 +243,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::sqrt`].
     ///
     /// A NaI is returned if `self` is NaI.
+    #[must_use]
     pub fn sqrt(self) -> Self {
         if self.is_nai() {
             return self;

--- a/src/elementary.rs
+++ b/src/elementary.rs
@@ -99,6 +99,7 @@ fn rem_euclid_2(x: f64) -> f64 {
 macro_rules! impl_log {
     ($(#[$meta:meta])* $f:ident, $f_impl:ident, $f_rd:ident, $f_ru:ident) => {
         $(#[$meta])*
+        #[must_use]
         pub fn $f(self) -> Self {
             self.$f_impl().0
         }
@@ -129,6 +130,7 @@ macro_rules! impl_log {
 macro_rules! impl_mono_inc {
     ($(#[$meta:meta])* $f:ident, $f_rd:ident, $f_ru:ident) => {
         $(#[$meta])*
+        #[must_use]
         pub fn $f(self) -> Self {
             if self.is_empty() {
                 return self;
@@ -145,6 +147,7 @@ impl Interval {
     /// | Domain      | Range      |
     /// | ----------- | ---------- |
     /// | $\[-1, 1\]$ | $\[0, π\]$ |
+    #[must_use]
     pub fn acos(self) -> Self {
         self.acos_impl().0
     }
@@ -171,6 +174,7 @@ impl Interval {
     /// | Domain    | Range     |
     /// | --------- | --------- |
     /// | $\[1, ∞)$ | $\[0, ∞)$ |
+    #[must_use]
     pub fn acosh(self) -> Self {
         self.acosh_impl().0
     }
@@ -197,6 +201,7 @@ impl Interval {
     /// | Domain      | Range           |
     /// | ----------- | --------------- |
     /// | $\[-1, 1\]$ | $\[-π/2, π/2\]$ |
+    #[must_use]
     pub fn asin(self) -> Self {
         self.asin_impl().0
     }
@@ -245,6 +250,7 @@ impl Interval {
     /// | Domain                | Range      |
     /// | --------------------- | ---------- |
     /// | $\R^2 ∖ \set{(0, 0)}$ | $(-π, π\]$ |
+    #[must_use]
     pub fn atan2(self, rhs: Self) -> Self {
         self.atan2_impl(rhs).0
     }
@@ -365,6 +371,7 @@ impl Interval {
     /// | Domain    | Range |
     /// | --------- | ----- |
     /// | $(-1, 1)$ | $\R$  |
+    #[must_use]
     pub fn atanh(self) -> Self {
         self.atanh_impl().0
     }
@@ -397,6 +404,7 @@ impl Interval {
     /// | Domain | Range       |
     /// | ------ | ----------- |
     /// | $\R$   | $\[-1, 1\]$ |
+    #[must_use]
     pub fn cos(self) -> Self {
         if self.is_empty() {
             return self;
@@ -443,6 +451,7 @@ impl Interval {
     /// | Domain | Range     |
     /// | ------ | --------- |
     /// | $\R$   | $\[1, ∞)$ |
+    #[must_use]
     pub fn cosh(self) -> Self {
         if self.is_empty() {
             return self;
@@ -529,6 +538,7 @@ impl Interval {
     /// | Domain                              | Range     |
     /// | ----------------------------------- | --------- |
     /// | $((0, ∞) × \R) ∪ (\set 0 × (0, ∞))$ | $\[0, ∞)$ |
+    #[must_use]
     pub fn pow(self, rhs: Self) -> Self {
         self.pow_impl(rhs).0
     }
@@ -609,6 +619,7 @@ impl Interval {
     /// | $n = 0$        | $\R$          | $\set 1$      |
     /// | $n < 0$, odd   | $\R ∖ \set 0$ | $\R ∖ \set 0$ |
     /// | $n < 0$, even  | $\R ∖ \set 0$ | $(0, ∞)$      |
+    #[must_use]
     pub fn pown(self, rhs: i32) -> Self {
         self.pown_impl(rhs).0
     }
@@ -673,6 +684,7 @@ impl Interval {
     /// | Domain | Range       |
     /// | ------ | ----------- |
     /// | $\R$   | $\[-1, 1\]$ |
+    #[must_use]
     pub fn sin(self) -> Self {
         if self.is_empty() {
             return self;
@@ -719,6 +731,7 @@ impl Interval {
     /// | Domain                            | Range |
     /// | --------------------------------- | ----- |
     /// | $\R ∖ \set{(n + 1/2) π ∣ n ∈ \Z}$ | $\R$  |
+    #[must_use]
     pub fn tan(self) -> Self {
         self.tan_impl().0
     }
@@ -763,6 +776,7 @@ macro_rules! impl_dec {
         #[doc = concat!("The decorated version of [`Interval::", stringify!($f), "`].")]
         ///
         /// A NaI is returned if `self` is NaI.
+        #[must_use]
         pub fn $f(self) -> Self {
             Self::set_dec(self.x.$f(), self.d)
         }
@@ -772,6 +786,7 @@ macro_rules! impl_dec {
         #[doc = concat!("The decorated version of [`Interval::", stringify!($f), "`].")]
         ///
         /// A NaI is returned if `self` is NaI.
+        #[must_use]
         pub fn $f(self) -> Self {
             let (y, d) = self.x.$f_impl();
             Self::set_dec(y, self.d.min(d))
@@ -784,6 +799,7 @@ macro_rules! impl_dec2 {
         #[doc = concat!("The decorated version of [`Interval::", stringify!($f), "`].")]
         ///
         /// A NaI is returned if `self` or `rhs` is NaI.
+        #[must_use]
         pub fn $f(self, rhs: Self) -> Self {
             let (z, d) = self.x.$f_impl(rhs.x);
             Self::set_dec(z, self.d.min(rhs.d.min(d)))
@@ -812,6 +828,7 @@ impl DecInterval {
     /// The decorated version of [`Interval::pown`].
     ///
     /// A NaI is returned if `self` is NaI.
+    #[must_use]
     pub fn pown(self, rhs: i32) -> Self {
         let (y, d) = self.x.pown_impl(rhs);
         Self::set_dec(y, self.d.min(d))

--- a/src/integer.rs
+++ b/src/integer.rs
@@ -20,6 +20,7 @@ impl Interval {
     /// ```
     ///
     /// See also: [`Interval::floor`], [`Interval::trunc`].
+    #[must_use]
     pub fn ceil(self) -> Self {
         // _mm_ceil_pd/_mm_floor_pd are slow, better to avoid shuffling them.
         // ceil([a, b]) = [-ceil(a); ceil(b)]
@@ -47,6 +48,7 @@ impl Interval {
     /// ```
     ///
     /// See also: [`Interval::ceil`], [`Interval::trunc`].
+    #[must_use]
     pub fn floor(self) -> Self {
         // floor([a, b]) = [-floor(a); floor(b)]
         let x = neg0(self.rep); // [a; b]
@@ -75,6 +77,7 @@ impl Interval {
     /// ```
     ///
     /// See also: [`Interval::round_ties_to_even`].
+    #[must_use]
     pub fn round(self) -> Self {
         Self {
             rep: round(self.rep),
@@ -102,6 +105,7 @@ impl Interval {
     /// ```
     ///
     /// See also: [`Interval::round`].
+    #[must_use]
     pub fn round_ties_to_even(self) -> Self {
         Self {
             rep: round_ties_to_even(self.rep),
@@ -128,6 +132,7 @@ impl Interval {
     /// assert_eq!(Interval::EMPTY.sign(), Interval::EMPTY);
     /// assert_eq!(Interval::ENTIRE.sign(), const_interval!(-1.0, 1.0));
     /// ```
+    #[must_use]
     pub fn sign(self) -> Self {
         if self.is_empty() {
             return Self::EMPTY;
@@ -164,6 +169,7 @@ impl Interval {
     /// ```
     ///
     /// See also: [`Interval::ceil`], [`Interval::floor`].
+    #[must_use]
     pub fn trunc(self) -> Self {
         Self {
             rep: trunc(self.rep),
@@ -182,6 +188,7 @@ macro_rules! impl_dec {
         #[doc = concat!("The decorated version of [`Interval::", stringify!($f), "`].")]
         ///
         /// A NaI is returned if `self` is NaI.
+        #[must_use]
         pub fn $f(self) -> Self {
             if self.is_nai() {
                 return self;

--- a/src/set_op.rs
+++ b/src/set_op.rs
@@ -7,6 +7,7 @@ impl Interval {
     /// | :----------------: | :--------: | :------------------------------------: |
     /// | $\self = ∅$        | $∅$        | $\[c, d\]$                             |
     /// | $\self = \[a, b\]$ | $\[a, b\]$ | $\[\min \set{a, c}, \max \set{b, d}\]$ |
+    #[must_use]
     pub fn convex_hull(self, rhs: Self) -> Self {
         if self.is_empty() {
             return rhs;
@@ -28,6 +29,7 @@ impl Interval {
     /// | :----------------: | :--------: | :------------------------------------: |
     /// | $\self = ∅$        | $∅$        | $∅$                                    |
     /// | $\self = \[a, b\]$ | $∅$        | $\[\max \set{a, c}, \min \set{b, d}\]$ |
+    #[must_use]
     pub fn intersection(self, rhs: Self) -> Self {
         if self.either_empty(rhs) {
             return Self::EMPTY;
@@ -53,6 +55,7 @@ macro_rules! impl_dec {
         /// and returns the result decorated with [`Decoration::Trv`].
         ///
         /// A NaI is returned if `self` or `rhs` is NaI.
+        #[must_use]
         pub fn $f(self, rhs: Self) -> Self {
             if self.is_nai() || rhs.is_nai() {
                 return Self::NAI;


### PR DESCRIPTION
This is convenient and `std` [does it for standard types](https://doc.rust-lang.org/std/primitive.f64.html#impl-Add%3C%26%27_%20f64%3E).