### PR TITLE
[feature] Implement some transcendental functions with crlibm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ default-features = false
 features = ["float", "integer", "rational"]
 optional = true
 
+[dependencies.crlibm]
+version = "*"
+optional = true
+git = "https://github.com/Chris00/rust-crlibm"
+
 [[example]]
 name = "exp"
 required-features = ["gmp", "libm"]

--- a/src/elementary.rs
+++ b/src/elementary.rs
@@ -1,92 +1,22 @@
 use crate::{classify::*, const_interval, interval::*};
-use gmp_mpfr_sys::mpfr;
-use rug::Float;
 
-macro_rules! mpfr_fn {
-    ($mpfr_f:ident, $f_rd:ident, $f_ru:ident) => {
-        fn $f_rd(x: f64) -> f64 {
-            mpfr_fn!($mpfr_f(x, RNDD))
-        }
+#[cfg_attr(feature = "crlibm", allow(dead_code))]
+mod mpfr;
+#[cfg(not(feature = "crlibm"))]
+use self::mpfr::*;
 
-        fn $f_ru(x: f64) -> f64 {
-            mpfr_fn!($mpfr_f(x, RNDU))
-        }
-    };
+#[cfg(feature = "crlibm")]
+pub use crlibm::*;
 
-    ($mpfr_f:ident($x:ident, $rnd:ident)) => {{
-        let mut x = Float::with_val(f64::MANTISSA_DIGITS, $x);
-        let rnd = mpfr::rnd_t::$rnd;
-        unsafe {
-            mpfr::$mpfr_f(x.as_raw_mut(), x.as_raw(), rnd);
-            mpfr::get_d(x.as_raw(), rnd)
-        }
-    }};
-}
+// Functions not provided by crlibm.
+#[cfg(feature = "crlibm")]
+pub use self::mpfr::{
+    acosh_rd, acosh_ru, asinh_rd, asinh_ru, atan2_rd, atan2_ru,
+    atanh_rd, atanh_ru, exp10_rd, exp10_ru, exp2_rd, exp2_ru,
+    pow_rd, pow_ru, pown_rd, pown_ru, tanh_rd, tanh_ru};
+// Functions provided by crlibm which could be interesting here:
+// cospi, sinpi, tanpi, atanpi, asinpi, acospi, exp_m1, ln_1p
 
-macro_rules! mpfr_fn2 {
-    ($mpfr_f:ident, $f_rd:ident, $f_ru:ident) => {
-        fn $f_rd(x: f64, y: f64) -> f64 {
-            mpfr_fn2!($mpfr_f(x, y, RNDD))
-        }
-
-        fn $f_ru(x: f64, y: f64) -> f64 {
-            mpfr_fn2!($mpfr_f(x, y, RNDU))
-        }
-    };
-
-    ($mpfr_f:ident($x:ident, $y:ident, $rnd:ident)) => {{
-        let mut x = Float::with_val(f64::MANTISSA_DIGITS, $x);
-        let y = Float::with_val(f64::MANTISSA_DIGITS, $y);
-        let rnd = mpfr::rnd_t::$rnd;
-        unsafe {
-            mpfr::$mpfr_f(x.as_raw_mut(), x.as_raw(), y.as_raw(), rnd);
-            mpfr::get_d(x.as_raw(), rnd)
-        }
-    }};
-}
-
-macro_rules! mpfr_fn_si {
-    ($mpfr_f:ident, $f_rd:ident, $f_ru:ident) => {
-        fn $f_rd(x: f64, y: i32) -> f64 {
-            mpfr_fn_si!($mpfr_f(x, y, RNDD))
-        }
-
-        fn $f_ru(x: f64, y: i32) -> f64 {
-            mpfr_fn_si!($mpfr_f(x, y, RNDU))
-        }
-    };
-
-    ($mpfr_f:ident($x:ident, $y:ident, $rnd:ident)) => {{
-        let mut x = Float::with_val(f64::MANTISSA_DIGITS, $x);
-        let rnd = mpfr::rnd_t::$rnd;
-        unsafe {
-            mpfr::$mpfr_f(x.as_raw_mut(), x.as_raw(), $y.into(), rnd);
-            mpfr::get_d(x.as_raw(), rnd)
-        }
-    }};
-}
-
-mpfr_fn!(acos, acos_rd, acos_ru);
-mpfr_fn!(acosh, acosh_rd, acosh_ru);
-mpfr_fn!(asin, asin_rd, asin_ru);
-mpfr_fn!(asinh, asinh_rd, asinh_ru);
-mpfr_fn!(atan, atan_rd, atan_ru);
-mpfr_fn2!(atan2, atan2_rd, atan2_ru);
-mpfr_fn!(atanh, atanh_rd, atanh_ru);
-mpfr_fn!(cos, cos_rd, cos_ru);
-mpfr_fn!(cosh, cosh_rd, cosh_ru);
-mpfr_fn!(exp, exp_rd, exp_ru);
-mpfr_fn!(exp10, exp10_rd, exp10_ru);
-mpfr_fn!(exp2, exp2_rd, exp2_ru);
-mpfr_fn!(log, ln_rd, ln_ru);
-mpfr_fn!(log10, log10_rd, log10_ru);
-mpfr_fn!(log2, log2_rd, log2_ru);
-mpfr_fn2!(pow, pow_rd, pow_ru);
-mpfr_fn_si!(pow_si, pown_rd, pown_ru);
-mpfr_fn!(sin, sin_rd, sin_ru);
-mpfr_fn!(sinh, sinh_rd, sinh_ru);
-mpfr_fn!(tan, tan_rd, tan_ru);
-mpfr_fn!(tanh, tanh_rd, tanh_ru);
 
 fn rem_euclid_2(x: f64) -> f64 {
     if 2.0 * (x / 2.0).floor() == x {

--- a/src/elementary/mpfr.rs
+++ b/src/elementary/mpfr.rs
@@ -1,0 +1,88 @@
+use gmp_mpfr_sys::mpfr;
+use rug::Float;
+
+macro_rules! mpfr_fn {
+    ($mpfr_f:ident, $f_rd:ident, $f_ru:ident) => {
+        pub fn $f_rd(x: f64) -> f64 {
+            mpfr_fn!($mpfr_f(x, RNDD))
+        }
+
+        pub fn $f_ru(x: f64) -> f64 {
+            mpfr_fn!($mpfr_f(x, RNDU))
+        }
+    };
+
+    ($mpfr_f:ident($x:ident, $rnd:ident)) => {{
+        let mut x = Float::with_val(f64::MANTISSA_DIGITS, $x);
+        let rnd = mpfr::rnd_t::$rnd;
+        unsafe {
+            mpfr::$mpfr_f(x.as_raw_mut(), x.as_raw(), rnd);
+            mpfr::get_d(x.as_raw(), rnd)
+        }
+    }};
+}
+
+macro_rules! mpfr_fn2 {
+    ($mpfr_f:ident, $f_rd:ident, $f_ru:ident) => {
+        pub fn $f_rd(x: f64, y: f64) -> f64 {
+            mpfr_fn2!($mpfr_f(x, y, RNDD))
+        }
+
+        pub fn $f_ru(x: f64, y: f64) -> f64 {
+            mpfr_fn2!($mpfr_f(x, y, RNDU))
+        }
+    };
+
+    ($mpfr_f:ident($x:ident, $y:ident, $rnd:ident)) => {{
+        let mut x = Float::with_val(f64::MANTISSA_DIGITS, $x);
+        let y = Float::with_val(f64::MANTISSA_DIGITS, $y);
+        let rnd = mpfr::rnd_t::$rnd;
+        unsafe {
+            mpfr::$mpfr_f(x.as_raw_mut(), x.as_raw(), y.as_raw(), rnd);
+            mpfr::get_d(x.as_raw(), rnd)
+        }
+    }};
+}
+
+macro_rules! mpfr_fn_si {
+    ($mpfr_f:ident, $f_rd:ident, $f_ru:ident) => {
+        pub fn $f_rd(x: f64, y: i32) -> f64 {
+            mpfr_fn_si!($mpfr_f(x, y, RNDD))
+        }
+
+        pub fn $f_ru(x: f64, y: i32) -> f64 {
+            mpfr_fn_si!($mpfr_f(x, y, RNDU))
+        }
+    };
+
+    ($mpfr_f:ident($x:ident, $y:ident, $rnd:ident)) => {{
+        let mut x = Float::with_val(f64::MANTISSA_DIGITS, $x);
+        let rnd = mpfr::rnd_t::$rnd;
+        unsafe {
+            mpfr::$mpfr_f(x.as_raw_mut(), x.as_raw(), $y.into(), rnd);
+            mpfr::get_d(x.as_raw(), rnd)
+        }
+    }};
+}
+
+mpfr_fn!(acos, acos_rd, acos_ru);
+mpfr_fn!(acosh, acosh_rd, acosh_ru);
+mpfr_fn!(asin, asin_rd, asin_ru);
+mpfr_fn!(asinh, asinh_rd, asinh_ru);
+mpfr_fn!(atan, atan_rd, atan_ru);
+mpfr_fn2!(atan2, atan2_rd, atan2_ru);
+mpfr_fn!(atanh, atanh_rd, atanh_ru);
+mpfr_fn!(cos, cos_rd, cos_ru);
+mpfr_fn!(cosh, cosh_rd, cosh_ru);
+mpfr_fn!(exp, exp_rd, exp_ru);
+mpfr_fn!(exp10, exp10_rd, exp10_ru);
+mpfr_fn!(exp2, exp2_rd, exp2_ru);
+mpfr_fn!(log, ln_rd, ln_ru);
+mpfr_fn!(log10, log10_rd, log10_ru);
+mpfr_fn!(log2, log2_rd, log2_ru);
+mpfr_fn2!(pow, pow_rd, pow_ru);
+mpfr_fn_si!(pow_si, pown_rd, pown_ru);
+mpfr_fn!(sin, sin_rd, sin_ru);
+mpfr_fn!(sinh, sinh_rd, sinh_ru);
+mpfr_fn!(tan, tan_rd, tan_ru);
+mpfr_fn!(tanh, tanh_rd, tanh_ru);


### PR DESCRIPTION
This PR is not ready to merge.  ATM, it is to enable you to perform experiments and discuss.

It implements a feature `crlibm` that implements some of the transcendental functions using [crlibm](https://github.com/Chris00/rust-crlibm).  Advantages:
- results are **guaranteed to be rounded to the closest machine number** according to the rounding mode (set by a suffix, the processor should be in “round to nearest” mode) so the intervals are tight;
- these functions are **30 times faster** than the `mpfr` ones.

If you agree that it would be a good thing to have, there are some things to be decided.
- You may want to audit the [crate crlibm](https://github.com/Chris00/rust-crlibm) (it is really just a thin wrapper around crlibm and it [runs on all platforms](https://github.com/Chris00/rust-crlibm/actions/runs/1637470957)).  I'll publish it on crate.io after that.
- Do you want `crlibm` to stay an option or should it be enabled by default? 😀
- Should the documentation say something about the speed (for the functions not present in crlibm — it avoids the user to wonder why using some functions is a lot slower)?
- There are various functions present in crlibm that IMHO are worth adding to `Interval`: `cospi`, `sinpi`, `tanpi`, `atanpi`, `asinpi`, `acospi`, `exp_m1`, and `ln_1p`.