### PR TITLE
Implement `cancel_minus` and `cancel_plus`

### DIFF
--- a/src/basic.rs
+++ b/src/basic.rs
@@ -1,8 +1,102 @@
 use crate::{classify::*, interval::*, simd::*};
+use std::{cmp::Ordering, unreachable};
 
 // NOTE: `neg`, `add`, `sub`, `mul` and `div` are implemented in arith.rs
 
 impl Interval {
+    /// When `self` and `rhs` are bounded, return the tightest
+    /// interval `z` such that `rhz + z` ⊇ `self` if such a `z` exists
+    /// (which is the case iff the width of `self` is greater or equal
+    /// to the width of `rhs`.  If `self` or `rhs` is unbounded or `z`
+    /// does not exists, return [`ENTIRE`][Self::ENTIRE].
+    ///
+    /// Mathematically, $\operatorname{cancel_minus}(y+z, y) = z$ but,
+    /// on a computer, this function may return a slight
+    /// overestimation of $z$.  Moreover, when `x.cancel_minus(y)` is
+    /// not `ENTIRE`, one has `x.cancel_minus(y)` ⊆ `x-y` but
+    /// generally not the equality.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use inari::*;
+    /// let y = const_interval!(0., 1.);
+    /// let z = const_interval!(3., 4.);
+    /// assert_eq!((y+z).cancel_minus(y), z);
+    /// ```
+    #[must_use]
+    pub fn cancel_minus(self, rhs: Self) -> Self {
+        if self.is_empty() && (rhs.is_empty() || rhs.is_common_interval()) {
+            return Self::EMPTY;
+        }
+        if !self.is_common_interval() || rhs.is_empty() || !rhs.is_common_interval() {
+            return Self::ENTIRE;
+        }
+        let x = self.rep; // [-a; b]
+        let y = rhs.rep; // [-c; d]
+        let z = sub_ru(x, y); // [▵(-a+c); ▵(b-d)] = [▿(a-c), ▵(b-d)]
+        let w = hadd_rn(x, y); // widths round to nearest, ≥ 0
+        let [wx, wy] = extract(w);
+        // `wx` and `wy` are not NaN as `x` and `y` are common intervals.
+        match wx.partial_cmp(&wy) {
+            Some(Ordering::Greater) => {
+                // width(x) > width(y) without rounding. `z.inf()`
+                // cannot be +∞ due to rounding downward.
+                Self { rep: z }
+            }
+            Some(Ordering::Less) => Self::ENTIRE,
+            Some(Ordering::Equal) => {
+                if wx == f64::INFINITY {
+                    // widths too large to be compared through their roundings
+                    let z_rn = sub_rn(x, y);
+                    let [z0, z1] = extract(z_rn);
+                    match (-z0).partial_cmp(&z1) {
+                        Some(Ordering::Less) => Self { rep: z },
+                        Some(Ordering::Greater) => Self::ENTIRE,
+                        Some(Ordering::Equal) => {
+                            // -z0 == z1.  Use the 2Sum algorithm to
+                            // get the remainders.
+                            let d1 = add_rn(z_rn, y);
+                            let d2 = sub_rn(z_rn, d1);
+                            let d1 = sub_rn(x, d1);
+                            let d2 = add_rn(y, d2);
+                            let [dz0, dz1] = extract(sub_rn(d1, d2));
+                            if -dz0 <= dz1 {
+                                Self { rep: z }
+                            } else {
+                                Self::ENTIRE
+                            }
+                        }
+                        None => unreachable!(),
+                    }
+                } else {
+                    // wx == wy < +∞. Use 2Sum to compute the remainders.
+                    // width(x) = wx + dx, width(y) = wy + dy
+                    let d1 = sub_rn(w, shuffle13(x, y));
+                    let d2 = sub_rn(w, d1);
+                    let d1 = sub_rn(shuffle02(x, y), d1);
+                    let d2 = sub_rn(shuffle13(x, y), d2);
+                    let [dx, dy] = extract(add_rn(d1, d2));
+                    if dx >= dy {
+                        Self { rep: z }
+                    } else {
+                        Self::ENTIRE
+                    }
+                }
+            }
+            None => unreachable!(),
+        }
+    }
+
+    /// `x.cancel_plus(y)` is `x.cancel_minus(-y)`.
+    ///
+    /// See [`cancel_minus`][Self::cancel_minus] for more information.
+    #[inline]
+    #[must_use]
+    pub fn cancel_plus(self, rhs: Self) -> Self {
+        self.cancel_minus(-rhs)
+    }
+
     /// Returns $(\self × \rhs) + \addend$.
     ///
     /// The domain and the range of the point function are:
@@ -204,6 +298,28 @@ impl Interval {
 }
 
 impl DecInterval {
+    /// The decorated version of [`Interval::cancel_minus`].
+    ///
+    /// A NaI is returned if `self` or `rhs` is NaI.
+    #[must_use]
+    pub fn cancel_minus(self, rhs: Self) -> Self {
+        if self.is_nai() || rhs.is_nai() {
+            return Self::NAI;
+        }
+        Self::set_dec(self.x.cancel_minus(rhs.x), Decoration::Trv)
+    }
+
+    /// The decorated version of [`Interval::cancel_plus`].
+    ///
+    /// A NaI is returned if `self` or `rhs` is NaI.
+    #[must_use]
+    pub fn cancel_plus(self, rhs: Self) -> Self {
+        if self.is_nai() || rhs.is_nai() {
+            return Self::NAI;
+        }
+        Self::set_dec(self.x.cancel_plus(rhs.x), Decoration::Trv)
+    }
+
     /// The decorated version of [`Interval::mul_add`].
     ///
     /// A NaI is returned if `self`, `rhs` or `addend` is NaI.
@@ -300,5 +416,25 @@ mod tests {
         assert!(DI::NAI.recip().is_nai());
         assert!(DI::NAI.sqrt().is_nai());
         assert!(DI::NAI.sqr().is_nai());
+    }
+
+    #[test]
+    fn cancel_minus() {
+        assert_eq!(
+            const_interval!(f64::MAX, f64::MAX).cancel_minus(const_interval!(f64::MIN, f64::MIN)),
+            const_interval!(f64::MAX, f64::INFINITY)
+        );
+        assert_eq!(
+            const_interval!(f64::MIN, f64::MIN).cancel_minus(const_interval!(f64::MAX, f64::MAX)),
+            const_interval!(f64::NEG_INFINITY, f64::MIN)
+        );
+        assert_eq!(
+            const_interval!(1e292, f64::MAX).cancel_minus(const_interval!(f64::MIN, f64::MIN)),
+            const_interval!(f64::MAX, f64::INFINITY)
+        );
+        assert_eq!(
+            const_interval!(f64::MAX, f64::MAX).cancel_minus(const_interval!(f64::MIN, -1e292)),
+            I::ENTIRE
+        );
     }
 }

--- a/src/simd/aarch64.rs
+++ b/src/simd/aarch64.rs
@@ -40,6 +40,10 @@ pub(crate) fn eq(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { transmute(vceqq_f64(x, y)) }
 }
 
+pub(crate) fn extract(x: F64X2) -> [f64; 2] {
+    unsafe { transmute::<_, [f64; 2]>(x) }
+}
+
 pub(crate) fn extract0(x: F64X2) -> f64 {
     unsafe { transmute::<_, [f64; 2]>(x)[0] }
 }
@@ -132,6 +136,18 @@ fn shuffle12(x: F64X2, y: F64X2) -> F64X2 {
     constant(extract1(x), extract0(y))
 }
 
+pub(crate) fn add_rn(x: F64X2, y: F64X2) -> F64X2 {
+    unsafe { vaddq_f64(x, y) }
+}
+
+pub(crate) fn sub_rn(x: F64X2, y: F64X2) -> F64X2 {
+    unsafe { vsubq_f64(x, y) }
+}
+
+pub(crate) fn hadd(x: F64X2, y: F64X2) -> F64X2 {
+    unsafe { constant(vaddvq_f64(x), vaddvq_f64(y)) }
+}
+
 macro_rules! impl_op_round {
     ($t:ty, $f:ident ($x:ident $(,$y:ident)*), $inst:literal, rd) => {
         impl_op_round!($t, $f ($x $(,$y)*), $inst, 0x800000);
@@ -165,6 +181,7 @@ impl_op_round!(f64, sqrt1_rd(x), "fsqrt {x:d}, {x:d}", rd);
 impl_op_round!(f64, sqrt1_ru(x), "fsqrt {x:d}, {x:d}", ru);
 impl_op_round!(f64, sub1_ru(x, y), "fsub {x:d}, {x:d}, {y:d}", ru);
 impl_op_round!(F64X2, add_ru(x, y), "fadd.2d {x:v}, {x:v}, {y:v}", ru);
+impl_op_round!(F64X2, sub_ru(x, y), "fsub.2d {x:v}, {x:v}, {y:v}", ru);
 impl_op_round!(F64X2, mul_ru(x, y), "fmul.2d {x:v}, {x:v}, {y:v}", ru);
 impl_op_round!(F64X2, div_ru(x, y), "fdiv.2d {x:v}, {x:v}, {y:v}", ru);
 

--- a/src/simd/x86_64.rs
+++ b/src/simd/x86_64.rs
@@ -108,14 +108,17 @@ pub(crate) fn round_ties_to_even(x: F64X2) -> F64X2 {
     unsafe { _mm_round_pd(x, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC) }
 }
 
+/// `shuffle02([x0, x1], [x2, x3]) = [x0, x2]`
 pub(crate) fn shuffle02(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { _mm_shuffle_pd(x, y, 0) }
 }
 
+/// `shuffle03([x0, x1], [x2, x3]) = [x0, x3]`
 pub(crate) fn shuffle03(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { _mm_shuffle_pd(x, y, 2) }
 }
 
+/// `shuffle13([x0, x1], [x2, x3]) = [x1, x3]`
 pub(crate) fn shuffle13(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { _mm_shuffle_pd(x, y, 3) }
 }
@@ -132,6 +135,7 @@ pub(crate) fn trunc(x: F64X2) -> F64X2 {
     unsafe { _mm_round_pd(x, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC) }
 }
 
+/// `shuffle13([x0, x1], [x2, x3]) = [x1, x2]`
 fn shuffle12(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { _mm_shuffle_pd(x, y, 1) }
 }

--- a/src/simd/x86_64.rs
+++ b/src/simd/x86_64.rs
@@ -37,6 +37,10 @@ pub(crate) fn eq(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { _mm_cmpeq_pd(x, y) }
 }
 
+pub(crate) fn extract(x: F64X2) -> [f64; 2] {
+    unsafe { transmute::<_, [f64; 2]>(x) }
+}
+
 pub(crate) fn extract0(x: F64X2) -> f64 {
     unsafe { transmute::<_, [f64; 2]>(x)[0] }
 }
@@ -142,6 +146,21 @@ fn shuffle12(x: F64X2, y: F64X2) -> F64X2 {
 
 fn xor(x: F64X2, y: F64X2) -> F64X2 {
     unsafe { _mm_xor_pd(x, y) }
+}
+
+/// `add_rn([x0, x1], [y0, y1]) = [x0 + y0, x1 + y1]` rounded to nearest.
+pub(crate) fn add_rn(x: F64X2, y: F64X2) -> F64X2 {
+    unsafe { _mm_add_pd(x, y) }
+}
+
+/// `sub_rn([x0, x1], [y0, y1]) = [x0 - y0, x1 - y1]` rounded to nearest.
+pub(crate) fn sub_rn(x: F64X2, y: F64X2) -> F64X2 {
+    unsafe { _mm_sub_pd(x, y) }
+}
+
+/// `hadd_rn([x0, x1], [y0, y1]) = [x0 + x1, y0 + y1]` rounded to nearest.
+pub(crate) fn hadd_rn(x: F64X2, y: F64X2) -> F64X2 {
+    unsafe { _mm_hadd_pd(x, y) }
 }
 
 cfg_if::cfg_if! {

--- a/src/simd/x86_64/avx512f.rs
+++ b/src/simd/x86_64/avx512f.rs
@@ -37,6 +37,13 @@ impl_op_round!(
 impl_op_round!(
     super::F64X2,
     zmm_reg,
+    sub_ru(x, y),
+    "vsubpd {x:z}, {x:z}, {y:z}",
+    ru
+);
+impl_op_round!(
+    super::F64X2,
+    zmm_reg,
     mul_ru(x, y),
     "vmulpd {x:z}, {x:z}, {y:z}",
     ru

--- a/src/simd/x86_64/avx_fma.rs
+++ b/src/simd/x86_64/avx_fma.rs
@@ -35,6 +35,7 @@ impl_op_round!(f64, sqrt1_rd(x), "vsqrtsd {x}, {x}, {x}", rd);
 impl_op_round!(f64, sqrt1_ru(x), "vsqrtsd {x}, {x}, {x}", ru);
 impl_op_round!(f64, sub1_ru(x, y), "vsubsd {x}, {x}, {y}", ru);
 impl_op_round!(super::F64X2, add_ru(x, y), "vaddpd {x}, {x}, {y}", ru);
+impl_op_round!(super::F64X2, sub_ru(x, y), "vsubpd {x}, {x}, {y}", ru);
 impl_op_round!(super::F64X2, mul_ru(x, y), "vmulpd {x}, {x}, {y}", ru);
 impl_op_round!(super::F64X2, div_ru(x, y), "vdivpd {x}, {x}, {y}", ru);
 impl_op_round!(

--- a/tests/itf1788.rs
+++ b/tests/itf1788.rs
@@ -16,7 +16,7 @@ mod itf1788_tests {
     mod ieee1788_constructors;
     mod ieee1788_exceptions;
     mod libieeep1788_bool;
-    //mod libieeep1788_cancel;
+    mod libieeep1788_cancel;
     mod libieeep1788_class;
     mod libieeep1788_elem;
     //mod libieeep1788_mul_rev;

--- a/tests/itf1788_tests/libieeep1788_cancel.rs
+++ b/tests/itf1788_tests/libieeep1788_cancel.rs
@@ -1,0 +1,290 @@
+/*
+ *
+ * Unit tests from libieeep1788 for cancellative addition and subtraction
+ * (Original author: Marco Nehmeier)
+ * converted into portable ITL format by Oliver Heimlich.
+ *
+ * Copyright 2013-2015 Marco Nehmeier (nehmeier@informatik.uni-wuerzburg.de)
+ * Copyright 2015-2017 Oliver Heimlich (oheim@posteo.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+//Language imports
+#![rustfmt::skip]
+
+//Test library imports
+
+//Arithmetic library imports
+
+//Preamble
+use crate::*;
+use inari::{DecInterval as DI, Decoration as D, Interval as I, Overlap as O};
+
+#[test]
+fn minimal_cancel_plus_test() {
+    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_plus(n2i(-5.0, 1.0)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_plus(n2i(-5.0, 1.0)), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_plus(n2i(-5.0, 1.0)), I::ENTIRE);
+    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_plus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_plus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_plus(n2i(1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_plus(n2i(f64::NEG_INFINITY, 1.0)), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_plus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 5.0).cancel_plus(n2i(1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 5.0).cancel_plus(n2i(f64::NEG_INFINITY, 1.0)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 5.0).cancel_plus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_plus(n2i(1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_plus(n2i(f64::NEG_INFINITY, 1.0)), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_plus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(1.0, 5.1)), I::ENTIRE);
+    assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(0.9, 5.0)), I::ENTIRE);
+    assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(0.9, 5.1)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_plus(n2i(-5.0, 10.1)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_plus(n2i(-5.1, 10.0)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_plus(n2i(-5.1, 10.1)), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_plus(n2i(-5.0, -0.9)), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_plus(n2i(-5.1, -1.0)), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_plus(n2i(-5.1, -0.9)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, -1.0).cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_plus(I::EMPTY), I::EMPTY);
+    assert_eq2!(I::EMPTY.cancel_plus(n2i(1.0, 10.0)), I::EMPTY);
+    assert_eq2!(I::EMPTY.cancel_plus(n2i(-5.0, 10.0)), I::EMPTY);
+    assert_eq2!(I::EMPTY.cancel_plus(n2i(-5.0, -1.0)), I::EMPTY);
+    assert_eq2!(n2i(-5.1, -0.0).cancel_plus(n2i(0.0, 5.0)), n2i(-0.09999999999999964, 0.0));
+    assert_eq2!(n2i(-5.1, -1.0).cancel_plus(n2i(1.0, 5.0)), n2i(-0.09999999999999964, 0.0));
+    assert_eq2!(n2i(-5.0, -0.9).cancel_plus(n2i(1.0, 5.0)), n2i(0.0, 0.09999999999999998));
+    assert_eq2!(n2i(-5.1, -0.9).cancel_plus(n2i(1.0, 5.0)), n2i(-0.09999999999999964, 0.09999999999999998));
+    assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(1.0, 5.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(-10.1, 5.0).cancel_plus(n2i(-5.0, 10.0)), n2i(-0.09999999999999964, 0.0));
+    assert_eq2!(n2i(-10.0, 5.1).cancel_plus(n2i(-5.0, 10.0)), n2i(0.0, 0.09999999999999964));
+    assert_eq2!(n2i(-10.1, 5.1).cancel_plus(n2i(-5.0, 10.0)), n2i(-0.09999999999999964, 0.09999999999999964));
+    assert_eq2!(n2i(-10.0, 5.0).cancel_plus(n2i(-5.0, 10.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(0.9, 5.0).cancel_plus(n2i(-5.0, -1.0)), n2i(-0.09999999999999998, 0.0));
+    assert_eq2!(n2i(1.0, 5.1).cancel_plus(n2i(-5.0, -1.0)), n2i(0.0, 0.09999999999999964));
+    assert_eq2!(n2i(0.0, 5.1).cancel_plus(n2i(-5.0, -0.0)), n2i(0.0, 0.09999999999999964));
+    assert_eq2!(n2i(0.9, 5.1).cancel_plus(n2i(-5.0, -1.0)), n2i(-0.09999999999999998, 0.09999999999999964));
+    assert_eq2!(n2i(1.0, 5.0).cancel_plus(n2i(-5.0, -1.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(0.0, 5.0).cancel_plus(n2i(-5.0, -0.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(1.9999999999999964, 1.9999999999999964).cancel_plus(n2i(-0.1, -0.1)), n2i(1.8999999999999964, 1.8999999999999966));
+    assert_eq2!(n2i(-0.1, 1.9999999999999964).cancel_plus(n2i(-0.1, 0.01)), n2i(-0.09000000000000001, 1.8999999999999966));
+    assert_eq2!(n2i(1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(1.7976931348623157e+308, 1.7976931348623157e+308)), n2i(1.7976931348623157e+308, f64::INFINITY));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)), n2i(0.0, 1.99584030953472e+292));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)), n2i(-1.99584030953472e+292, 0.0));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
+    assert_eq2!(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 2.2204460492503128e-16).cancel_plus(n2i(-1.0, 2.2204460492503126e-16)), n2i(-0.9999999999999999, -0.9999999999999998));
+    assert_eq2!(n2i(-1.0, 2.2204460492503126e-16).cancel_plus(n2i(-1.0, 2.2204460492503128e-16)), I::ENTIRE);
+}
+
+#[test]
+fn minimal_cancel_plus_dec_test() {
+    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Def).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(nd2di(-5.0, 1.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Trv).cancel_plus(nd2di(-5.0, 1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(-5.0, 1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Def).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(1.0, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 5.0, D::Dac).cancel_plus(nd2di(1.0, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 5.0, D::Def).cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 5.0, D::Com).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(1.0, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Com).cancel_plus(nd2di(1.0, 5.1, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Dac).cancel_plus(nd2di(0.9, 5.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Def).cancel_plus(nd2di(0.9, 5.1, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Trv).cancel_plus(nd2di(-5.0, 10.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Com).cancel_plus(nd2di(-5.1, 10.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Dac).cancel_plus(nd2di(-5.1, 10.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, -0.9, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Trv).cancel_plus(nd2di(-5.1, -1.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Dac).cancel_plus(nd2di(-5.1, -0.9, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, -1.0, D::Trv).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Def).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Com).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_plus(DI::EMPTY), DI::EMPTY);
+    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(1.0, 10.0, D::Dac)), DI::EMPTY);
+    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(-5.0, 10.0, D::Def)), DI::EMPTY);
+    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(-5.0, -1.0, D::Com)), DI::EMPTY);
+    assert_eq2!(nd2di(-5.1, -0.0, D::Com).cancel_plus(nd2di(0.0, 5.0, D::Com)), nd2di(-0.09999999999999964, 0.0, D::Trv));
+    assert_eq2!(nd2di(-5.1, -1.0, D::Com).cancel_plus(nd2di(1.0, 5.0, D::Dac)), nd2di(-0.09999999999999964, 0.0, D::Trv));
+    assert_eq2!(nd2di(-5.0, -0.9, D::Com).cancel_plus(nd2di(1.0, 5.0, D::Def)), nd2di(0.0, 0.09999999999999998, D::Trv));
+    assert_eq2!(nd2di(-5.1, -0.9, D::Dac).cancel_plus(nd2di(1.0, 5.0, D::Trv)), nd2di(-0.09999999999999964, 0.09999999999999998, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Dac).cancel_plus(nd2di(1.0, 5.0, D::Com)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(-10.1, 5.0, D::Dac).cancel_plus(nd2di(-5.0, 10.0, D::Dac)), nd2di(-0.09999999999999964, 0.0, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.1, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Def)), nd2di(0.0, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(-10.1, 5.1, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Trv)), nd2di(-0.09999999999999964, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Com)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(0.9, 5.0, D::Trv).cancel_plus(nd2di(-5.0, -1.0, D::Dac)), nd2di(-0.09999999999999998, 0.0, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.1, D::Trv).cancel_plus(nd2di(-5.0, -1.0, D::Def)), nd2di(0.0, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(0.0, 5.1, D::Trv).cancel_plus(nd2di(-5.0, -0.0, D::Trv)), nd2di(0.0, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(0.9, 5.1, D::Com).cancel_plus(nd2di(-5.0, -1.0, D::Com)), nd2di(-0.09999999999999998, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Dac).cancel_plus(nd2di(-5.0, -1.0, D::Dac)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(0.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, -0.0, D::Trv)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(1.9999999999999964, 1.9999999999999964, D::Com).cancel_plus(nd2di(-0.1, -0.1, D::Com)), nd2di(1.8999999999999964, 1.8999999999999966, D::Trv));
+    assert_eq2!(nd2di(-0.1, 1.9999999999999964, D::Dac).cancel_plus(nd2di(-0.1, 0.01, D::Com)), nd2di(-0.09000000000000001, 1.8999999999999966, D::Trv));
+    assert_eq2!(nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(1.7976931348623157e+308, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Dac).cancel_plus(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com)), nd2di(0.0, 1.99584030953472e+292, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Dac).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com)), nd2di(-1.99584030953472e+292, 0.0, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 2.2204460492503128e-16, D::Dac).cancel_plus(nd2di(-1.0, 2.2204460492503126e-16, D::Com)), nd2di(-0.9999999999999999, -0.9999999999999998, D::Trv));
+    assert_eq2!(nd2di(-1.0, 2.2204460492503126e-16, D::Def).cancel_plus(nd2di(-1.0, 2.2204460492503128e-16, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+}
+
+#[test]
+fn minimal_cancel_minus_test() {
+    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_minus(n2i(-1.0, 5.0)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_minus(n2i(-1.0, 5.0)), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_minus(n2i(-1.0, 5.0)), I::ENTIRE);
+    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_minus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_minus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_minus(n2i(f64::NEG_INFINITY, -1.0)), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_minus(n2i(-1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_minus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 5.0).cancel_minus(n2i(f64::NEG_INFINITY, -1.0)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 5.0).cancel_minus(n2i(-1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 5.0).cancel_minus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_minus(n2i(f64::NEG_INFINITY, -1.0)), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_minus(n2i(-1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(I::ENTIRE.cancel_minus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(n2i(-5.0, -1.0).cancel_minus(n2i(-5.1, -1.0)), I::ENTIRE);
+    assert_eq2!(n2i(-5.0, -1.0).cancel_minus(n2i(-5.0, -0.9)), I::ENTIRE);
+    assert_eq2!(n2i(-5.0, -1.0).cancel_minus(n2i(-5.1, -0.9)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_minus(n2i(-10.1, 5.0)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_minus(n2i(-10.0, 5.1)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_minus(n2i(-10.1, 5.1)), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_minus(n2i(0.9, 5.0)), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_minus(n2i(1.0, 5.1)), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_minus(n2i(0.9, 5.1)), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, -1.0).cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(-10.0, 5.0).cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(n2i(1.0, 5.0).cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(I::EMPTY.cancel_minus(I::EMPTY), I::EMPTY);
+    assert_eq2!(I::EMPTY.cancel_minus(n2i(-10.0, -1.0)), I::EMPTY);
+    assert_eq2!(I::EMPTY.cancel_minus(n2i(-10.0, 5.0)), I::EMPTY);
+    assert_eq2!(I::EMPTY.cancel_minus(n2i(1.0, 5.0)), I::EMPTY);
+    assert_eq2!(n2i(-5.1, -0.0).cancel_minus(n2i(-5.0, 0.0)), n2i(-0.09999999999999964, 0.0));
+    assert_eq2!(n2i(-5.1, -1.0).cancel_minus(n2i(-5.0, -1.0)), n2i(-0.09999999999999964, 0.0));
+    assert_eq2!(n2i(-5.0, -0.9).cancel_minus(n2i(-5.0, -1.0)), n2i(0.0, 0.09999999999999998));
+    assert_eq2!(n2i(-5.1, -0.9).cancel_minus(n2i(-5.0, -1.0)), n2i(-0.09999999999999964, 0.09999999999999998));
+    assert_eq2!(n2i(-5.0, -1.0).cancel_minus(n2i(-5.0, -1.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(-10.1, 5.0).cancel_minus(n2i(-10.0, 5.0)), n2i(-0.09999999999999964, 0.0));
+    assert_eq2!(n2i(-10.0, 5.1).cancel_minus(n2i(-10.0, 5.0)), n2i(0.0, 0.09999999999999964));
+    assert_eq2!(n2i(-10.1, 5.1).cancel_minus(n2i(-10.0, 5.0)), n2i(-0.09999999999999964, 0.09999999999999964));
+    assert_eq2!(n2i(-10.0, 5.0).cancel_minus(n2i(-10.0, 5.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(0.9, 5.0).cancel_minus(n2i(1.0, 5.0)), n2i(-0.09999999999999998, 0.0));
+    assert_eq2!(n2i(-0.0, 5.1).cancel_minus(n2i(0.0, 5.0)), n2i(0.0, 0.09999999999999964));
+    assert_eq2!(n2i(1.0, 5.1).cancel_minus(n2i(1.0, 5.0)), n2i(0.0, 0.09999999999999964));
+    assert_eq2!(n2i(0.9, 5.1).cancel_minus(n2i(1.0, 5.0)), n2i(-0.09999999999999998, 0.09999999999999964));
+    assert_eq2!(n2i(1.0, 5.0).cancel_minus(n2i(1.0, 5.0)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(-5.0, 1.0).cancel_minus(n2i(-1.0, 5.0)), n2i(-4.0, -4.0));
+    assert_eq2!(n2i(-5.0, 0.0).cancel_minus(n2i(-0.0, 5.0)), n2i(-5.0, -5.0));
+    assert_eq2!(n2i(1.9999999999999964, 1.9999999999999964).cancel_minus(n2i(0.1, 0.1)), n2i(1.8999999999999964, 1.8999999999999966));
+    assert_eq2!(n2i(-0.1, 1.9999999999999964).cancel_minus(n2i(-0.01, 0.1)), n2i(-0.09000000000000001, 1.8999999999999966));
+    assert_eq2!(n2i(1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, -1.7976931348623157e+308)), n2i(1.7976931348623157e+308, f64::INFINITY));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)), n2i(0.0, 1.99584030953472e+292));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)), n2i(-1.99584030953472e+292, 0.0));
+    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
+    assert_eq2!(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
+    assert_eq2!(n2i(5e-324, 5e-324).cancel_minus(n2i(5e-324, 5e-324)), n2i(0.0, 0.0));
+    assert_eq2!(n2i(5e-324, 5e-324).cancel_minus(n2i(-5e-324, -5e-324)), n2i(1e-323, 1e-323));
+    assert_eq2!(n2i(2.2250738585072014e-308, 2.2250738585072024e-308).cancel_minus(n2i(2.2250738585072014e-308, 2.225073858507202e-308)), n2i(0.0, 5e-324));
+    assert_eq2!(n2i(2.2250738585072014e-308, 2.225073858507202e-308).cancel_minus(n2i(2.2250738585072014e-308, 2.2250738585072024e-308)), I::ENTIRE);
+    assert_eq2!(n2i(-1.0, 2.2204460492503128e-16).cancel_minus(n2i(-2.2204460492503126e-16, 1.0)), n2i(-0.9999999999999999, -0.9999999999999998));
+    assert_eq2!(n2i(-1.0, 2.2204460492503126e-16).cancel_minus(n2i(-2.2204460492503128e-16, 1.0)), I::ENTIRE);
+}
+
+#[test]
+fn minimal_cancel_minus_dec_test() {
+    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Def).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Trv).cancel_minus(nd2di(-1.0, 5.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, 5.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, 5.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Def).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Trv).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(-1.0, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 5.0, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 5.0, D::Def).cancel_minus(nd2di(-1.0, f64::INFINITY, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 5.0, D::Com).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Com).cancel_minus(nd2di(-5.1, -1.0, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Dac).cancel_minus(nd2di(-5.0, -0.9, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Def).cancel_minus(nd2di(-5.1, -0.9, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Trv).cancel_minus(nd2di(-10.1, 5.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Com).cancel_minus(nd2di(-10.0, 5.1, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Dac).cancel_minus(nd2di(-10.1, 5.1, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Def).cancel_minus(nd2di(0.9, 5.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Trv).cancel_minus(nd2di(1.0, 5.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Com).cancel_minus(nd2di(0.9, 5.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, -1.0, D::Com).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Dac).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Def).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(DI::EMPTY.cancel_minus(DI::EMPTY), DI::EMPTY);
+    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(-10.0, -1.0, D::Com)), DI::EMPTY);
+    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(-10.0, 5.0, D::Dac)), DI::EMPTY);
+    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(1.0, 5.0, D::Def)), DI::EMPTY);
+    assert_eq2!(nd2di(-5.1, -0.0, D::Com).cancel_minus(nd2di(-5.0, 0.0, D::Com)), nd2di(-0.09999999999999964, 0.0, D::Trv));
+    assert_eq2!(nd2di(-5.1, -1.0, D::Dac).cancel_minus(nd2di(-5.0, -1.0, D::Com)), nd2di(-0.09999999999999964, 0.0, D::Trv));
+    assert_eq2!(nd2di(-5.0, -0.9, D::Def).cancel_minus(nd2di(-5.0, -1.0, D::Com)), nd2di(0.0, 0.09999999999999998, D::Trv));
+    assert_eq2!(nd2di(-5.1, -0.9, D::Trv).cancel_minus(nd2di(-5.0, -1.0, D::Com)), nd2di(-0.09999999999999964, 0.09999999999999998, D::Trv));
+    assert_eq2!(nd2di(-5.0, -1.0, D::Com).cancel_minus(nd2di(-5.0, -1.0, D::Dac)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(-10.1, 5.0, D::Dac).cancel_minus(nd2di(-10.0, 5.0, D::Dac)), nd2di(-0.09999999999999964, 0.0, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.1, D::Def).cancel_minus(nd2di(-10.0, 5.0, D::Dac)), nd2di(0.0, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(-10.1, 5.1, D::Trv).cancel_minus(nd2di(-10.0, 5.0, D::Def)), nd2di(-0.09999999999999964, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(-10.0, 5.0, D::Com).cancel_minus(nd2di(-10.0, 5.0, D::Def)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(0.9, 5.0, D::Dac).cancel_minus(nd2di(1.0, 5.0, D::Def)), nd2di(-0.09999999999999998, 0.0, D::Trv));
+    assert_eq2!(nd2di(-0.0, 5.1, D::Def).cancel_minus(nd2di(0.0, 5.0, D::Def)), nd2di(0.0, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.1, D::Trv).cancel_minus(nd2di(1.0, 5.0, D::Trv)), nd2di(0.0, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(0.9, 5.1, D::Com).cancel_minus(nd2di(1.0, 5.0, D::Trv)), nd2di(-0.09999999999999998, 0.09999999999999964, D::Trv));
+    assert_eq2!(nd2di(1.0, 5.0, D::Dac).cancel_minus(nd2di(1.0, 5.0, D::Com)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(-5.0, 1.0, D::Def).cancel_minus(nd2di(-1.0, 5.0, D::Def)), nd2di(-4.0, -4.0, D::Trv));
+    assert_eq2!(nd2di(-5.0, 0.0, D::Trv).cancel_minus(nd2di(-0.0, 5.0, D::Trv)), nd2di(-5.0, -5.0, D::Trv));
+    assert_eq2!(nd2di(1.9999999999999964, 1.9999999999999964, D::Com).cancel_minus(nd2di(0.1, 0.1, D::Com)), nd2di(1.8999999999999964, 1.8999999999999966, D::Trv));
+    assert_eq2!(nd2di(-0.1, 1.9999999999999964, D::Def).cancel_minus(nd2di(-0.01, 0.1, D::Dac)), nd2di(-0.09000000000000001, 1.8999999999999966, D::Trv));
+    assert_eq2!(nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, -1.7976931348623157e+308, D::Com)), nd2di(1.7976931348623157e+308, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com)), nd2di(0.0, 1.99584030953472e+292, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com)), nd2di(-1.99584030953472e+292, 0.0, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(5e-324, 5e-324, D::Com).cancel_minus(nd2di(5e-324, 5e-324, D::Com)), nd2di(0.0, 0.0, D::Trv));
+    assert_eq2!(nd2di(5e-324, 5e-324, D::Com).cancel_minus(nd2di(-5e-324, -5e-324, D::Dac)), nd2di(1e-323, 1e-323, D::Trv));
+    assert_eq2!(nd2di(2.2250738585072014e-308, 2.2250738585072024e-308, D::Dac).cancel_minus(nd2di(2.2250738585072014e-308, 2.225073858507202e-308, D::Dac)), nd2di(0.0, 5e-324, D::Trv));
+    assert_eq2!(nd2di(2.2250738585072014e-308, 2.225073858507202e-308, D::Def).cancel_minus(nd2di(2.2250738585072014e-308, 2.2250738585072024e-308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(nd2di(-1.0, 2.2204460492503128e-16, D::Com).cancel_minus(nd2di(-2.2204460492503126e-16, 1.0, D::Dac)), nd2di(-0.9999999999999999, -0.9999999999999998, D::Trv));
+    assert_eq2!(nd2di(-1.0, 2.2204460492503126e-16, D::Def).cancel_minus(nd2di(-2.2204460492503128e-16, 1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+}

--- a/tests/itf1788_tests/libieeep1788_cancel.rs
+++ b/tests/itf1788_tests/libieeep1788_cancel.rs
@@ -21,7 +21,6 @@
  *
  */
 //Language imports
-#![rustfmt::skip]
 
 //Test library imports
 
@@ -33,22 +32,43 @@ use inari::{DecInterval as DI, Decoration as D, Interval as I, Overlap as O};
 
 #[test]
 fn minimal_cancel_plus_test() {
-    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_plus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(
+        n2i(f64::NEG_INFINITY, -1.0).cancel_plus(I::EMPTY),
+        I::ENTIRE
+    );
     assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_plus(I::EMPTY), I::ENTIRE);
     assert_eq2!(I::ENTIRE.cancel_plus(I::EMPTY), I::ENTIRE);
-    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_plus(n2i(-5.0, 1.0)), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_plus(n2i(-5.0, 1.0)), I::ENTIRE);
+    assert_eq2!(
+        n2i(f64::NEG_INFINITY, -1.0).cancel_plus(n2i(-5.0, 1.0)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.0, f64::INFINITY).cancel_plus(n2i(-5.0, 1.0)),
+        I::ENTIRE
+    );
     assert_eq2!(I::ENTIRE.cancel_plus(n2i(-5.0, 1.0)), I::ENTIRE);
-    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_plus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(
+        n2i(f64::NEG_INFINITY, -1.0).cancel_plus(I::ENTIRE),
+        I::ENTIRE
+    );
     assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_plus(I::ENTIRE), I::ENTIRE);
     assert_eq2!(I::EMPTY.cancel_plus(n2i(1.0, f64::INFINITY)), I::ENTIRE);
     assert_eq2!(I::EMPTY.cancel_plus(n2i(f64::NEG_INFINITY, 1.0)), I::ENTIRE);
     assert_eq2!(I::EMPTY.cancel_plus(I::ENTIRE), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, 5.0).cancel_plus(n2i(1.0, f64::INFINITY)), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, 5.0).cancel_plus(n2i(f64::NEG_INFINITY, 1.0)), I::ENTIRE);
+    assert_eq2!(
+        n2i(-1.0, 5.0).cancel_plus(n2i(1.0, f64::INFINITY)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.0, 5.0).cancel_plus(n2i(f64::NEG_INFINITY, 1.0)),
+        I::ENTIRE
+    );
     assert_eq2!(n2i(-1.0, 5.0).cancel_plus(I::ENTIRE), I::ENTIRE);
     assert_eq2!(I::ENTIRE.cancel_plus(n2i(1.0, f64::INFINITY)), I::ENTIRE);
-    assert_eq2!(I::ENTIRE.cancel_plus(n2i(f64::NEG_INFINITY, 1.0)), I::ENTIRE);
+    assert_eq2!(
+        I::ENTIRE.cancel_plus(n2i(f64::NEG_INFINITY, 1.0)),
+        I::ENTIRE
+    );
     assert_eq2!(I::ENTIRE.cancel_plus(I::ENTIRE), I::ENTIRE);
     assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(1.0, 5.1)), I::ENTIRE);
     assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(0.9, 5.0)), I::ENTIRE);
@@ -66,112 +86,423 @@ fn minimal_cancel_plus_test() {
     assert_eq2!(I::EMPTY.cancel_plus(n2i(1.0, 10.0)), I::EMPTY);
     assert_eq2!(I::EMPTY.cancel_plus(n2i(-5.0, 10.0)), I::EMPTY);
     assert_eq2!(I::EMPTY.cancel_plus(n2i(-5.0, -1.0)), I::EMPTY);
-    assert_eq2!(n2i(-5.1, -0.0).cancel_plus(n2i(0.0, 5.0)), n2i(-0.09999999999999964, 0.0));
-    assert_eq2!(n2i(-5.1, -1.0).cancel_plus(n2i(1.0, 5.0)), n2i(-0.09999999999999964, 0.0));
-    assert_eq2!(n2i(-5.0, -0.9).cancel_plus(n2i(1.0, 5.0)), n2i(0.0, 0.09999999999999998));
-    assert_eq2!(n2i(-5.1, -0.9).cancel_plus(n2i(1.0, 5.0)), n2i(-0.09999999999999964, 0.09999999999999998));
+    assert_eq2!(
+        n2i(-5.1, -0.0).cancel_plus(n2i(0.0, 5.0)),
+        n2i(-0.09999999999999964, 0.0)
+    );
+    assert_eq2!(
+        n2i(-5.1, -1.0).cancel_plus(n2i(1.0, 5.0)),
+        n2i(-0.09999999999999964, 0.0)
+    );
+    assert_eq2!(
+        n2i(-5.0, -0.9).cancel_plus(n2i(1.0, 5.0)),
+        n2i(0.0, 0.09999999999999998)
+    );
+    assert_eq2!(
+        n2i(-5.1, -0.9).cancel_plus(n2i(1.0, 5.0)),
+        n2i(-0.09999999999999964, 0.09999999999999998)
+    );
     assert_eq2!(n2i(-5.0, -1.0).cancel_plus(n2i(1.0, 5.0)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(-10.1, 5.0).cancel_plus(n2i(-5.0, 10.0)), n2i(-0.09999999999999964, 0.0));
-    assert_eq2!(n2i(-10.0, 5.1).cancel_plus(n2i(-5.0, 10.0)), n2i(0.0, 0.09999999999999964));
-    assert_eq2!(n2i(-10.1, 5.1).cancel_plus(n2i(-5.0, 10.0)), n2i(-0.09999999999999964, 0.09999999999999964));
+    assert_eq2!(
+        n2i(-10.1, 5.0).cancel_plus(n2i(-5.0, 10.0)),
+        n2i(-0.09999999999999964, 0.0)
+    );
+    assert_eq2!(
+        n2i(-10.0, 5.1).cancel_plus(n2i(-5.0, 10.0)),
+        n2i(0.0, 0.09999999999999964)
+    );
+    assert_eq2!(
+        n2i(-10.1, 5.1).cancel_plus(n2i(-5.0, 10.0)),
+        n2i(-0.09999999999999964, 0.09999999999999964)
+    );
     assert_eq2!(n2i(-10.0, 5.0).cancel_plus(n2i(-5.0, 10.0)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(0.9, 5.0).cancel_plus(n2i(-5.0, -1.0)), n2i(-0.09999999999999998, 0.0));
-    assert_eq2!(n2i(1.0, 5.1).cancel_plus(n2i(-5.0, -1.0)), n2i(0.0, 0.09999999999999964));
-    assert_eq2!(n2i(0.0, 5.1).cancel_plus(n2i(-5.0, -0.0)), n2i(0.0, 0.09999999999999964));
-    assert_eq2!(n2i(0.9, 5.1).cancel_plus(n2i(-5.0, -1.0)), n2i(-0.09999999999999998, 0.09999999999999964));
+    assert_eq2!(
+        n2i(0.9, 5.0).cancel_plus(n2i(-5.0, -1.0)),
+        n2i(-0.09999999999999998, 0.0)
+    );
+    assert_eq2!(
+        n2i(1.0, 5.1).cancel_plus(n2i(-5.0, -1.0)),
+        n2i(0.0, 0.09999999999999964)
+    );
+    assert_eq2!(
+        n2i(0.0, 5.1).cancel_plus(n2i(-5.0, -0.0)),
+        n2i(0.0, 0.09999999999999964)
+    );
+    assert_eq2!(
+        n2i(0.9, 5.1).cancel_plus(n2i(-5.0, -1.0)),
+        n2i(-0.09999999999999998, 0.09999999999999964)
+    );
     assert_eq2!(n2i(1.0, 5.0).cancel_plus(n2i(-5.0, -1.0)), n2i(0.0, 0.0));
     assert_eq2!(n2i(0.0, 5.0).cancel_plus(n2i(-5.0, -0.0)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(1.9999999999999964, 1.9999999999999964).cancel_plus(n2i(-0.1, -0.1)), n2i(1.8999999999999964, 1.8999999999999966));
-    assert_eq2!(n2i(-0.1, 1.9999999999999964).cancel_plus(n2i(-0.1, 0.01)), n2i(-0.09000000000000001, 1.8999999999999966));
-    assert_eq2!(n2i(1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(1.7976931348623157e+308, 1.7976931348623157e+308)), n2i(1.7976931348623157e+308, f64::INFINITY));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)), n2i(0.0, 1.99584030953472e+292));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)), n2i(-1.99584030953472e+292, 0.0));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
-    assert_eq2!(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308).cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, 2.2204460492503128e-16).cancel_plus(n2i(-1.0, 2.2204460492503126e-16)), n2i(-0.9999999999999999, -0.9999999999999998));
-    assert_eq2!(n2i(-1.0, 2.2204460492503126e-16).cancel_plus(n2i(-1.0, 2.2204460492503128e-16)), I::ENTIRE);
+    assert_eq2!(
+        n2i(1.9999999999999964, 1.9999999999999964).cancel_plus(n2i(-0.1, -0.1)),
+        n2i(1.8999999999999964, 1.8999999999999966)
+    );
+    assert_eq2!(
+        n2i(-0.1, 1.9999999999999964).cancel_plus(n2i(-0.1, 0.01)),
+        n2i(-0.09000000000000001, 1.8999999999999966)
+    );
+    assert_eq2!(
+        n2i(1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_plus(n2i(1.7976931348623157e+308, 1.7976931348623157e+308)),
+        n2i(1.7976931348623157e+308, f64::INFINITY)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)),
+        n2i(0.0, 0.0)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_plus(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)),
+        n2i(0.0, 1.99584030953472e+292)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)),
+        n2i(-1.99584030953472e+292, 0.0)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)
+            .cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)
+            .cancel_plus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.0, 2.2204460492503128e-16).cancel_plus(n2i(-1.0, 2.2204460492503126e-16)),
+        n2i(-0.9999999999999999, -0.9999999999999998)
+    );
+    assert_eq2!(
+        n2i(-1.0, 2.2204460492503126e-16).cancel_plus(n2i(-1.0, 2.2204460492503128e-16)),
+        I::ENTIRE
+    );
 }
 
 #[test]
 fn minimal_cancel_plus_dec_test() {
-    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Def).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(nd2di(-5.0, 1.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Trv).cancel_plus(nd2di(-5.0, 1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(-5.0, 1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Def).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(1.0, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(DI::EMPTY.cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 5.0, D::Dac).cancel_plus(nd2di(1.0, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 5.0, D::Def).cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 5.0, D::Com).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(1.0, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Com).cancel_plus(nd2di(1.0, 5.1, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Dac).cancel_plus(nd2di(0.9, 5.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Def).cancel_plus(nd2di(0.9, 5.1, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Trv).cancel_plus(nd2di(-5.0, 10.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Com).cancel_plus(nd2di(-5.1, 10.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Dac).cancel_plus(nd2di(-5.1, 10.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, -0.9, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Trv).cancel_plus(nd2di(-5.1, -1.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Dac).cancel_plus(nd2di(-5.1, -0.9, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, -1.0, D::Trv).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Def).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Com).cancel_plus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, f64::INFINITY, D::Def).cancel_plus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def).cancel_plus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(nd2di(-5.0, 1.0, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, f64::INFINITY, D::Trv).cancel_plus(nd2di(-5.0, 1.0, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(-5.0, 1.0, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_plus(nd2di(
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, f64::INFINITY, D::Def).cancel_plus(nd2di(
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        DI::EMPTY.cancel_plus(nd2di(1.0, f64::INFINITY, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        DI::EMPTY.cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Trv)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        DI::EMPTY.cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 5.0, D::Dac).cancel_plus(nd2di(1.0, f64::INFINITY, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 5.0, D::Def).cancel_plus(nd2di(f64::NEG_INFINITY, 1.0, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 5.0, D::Com).cancel_plus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(
+            1.0,
+            f64::INFINITY,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(
+            f64::NEG_INFINITY,
+            1.0,
+            D::Def
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_plus(nd2di(
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Com).cancel_plus(nd2di(1.0, 5.1, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Dac).cancel_plus(nd2di(0.9, 5.0, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Def).cancel_plus(nd2di(0.9, 5.1, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Trv).cancel_plus(nd2di(-5.0, 10.1, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Com).cancel_plus(nd2di(-5.1, 10.0, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Dac).cancel_plus(nd2di(-5.1, 10.1, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, -0.9, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Trv).cancel_plus(nd2di(-5.1, -1.0, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Dac).cancel_plus(nd2di(-5.1, -0.9, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, -1.0, D::Trv).cancel_plus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Def).cancel_plus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Com).cancel_plus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
     assert_eq2!(DI::EMPTY.cancel_plus(DI::EMPTY), DI::EMPTY);
     assert_eq2!(DI::EMPTY.cancel_plus(nd2di(1.0, 10.0, D::Dac)), DI::EMPTY);
     assert_eq2!(DI::EMPTY.cancel_plus(nd2di(-5.0, 10.0, D::Def)), DI::EMPTY);
     assert_eq2!(DI::EMPTY.cancel_plus(nd2di(-5.0, -1.0, D::Com)), DI::EMPTY);
-    assert_eq2!(nd2di(-5.1, -0.0, D::Com).cancel_plus(nd2di(0.0, 5.0, D::Com)), nd2di(-0.09999999999999964, 0.0, D::Trv));
-    assert_eq2!(nd2di(-5.1, -1.0, D::Com).cancel_plus(nd2di(1.0, 5.0, D::Dac)), nd2di(-0.09999999999999964, 0.0, D::Trv));
-    assert_eq2!(nd2di(-5.0, -0.9, D::Com).cancel_plus(nd2di(1.0, 5.0, D::Def)), nd2di(0.0, 0.09999999999999998, D::Trv));
-    assert_eq2!(nd2di(-5.1, -0.9, D::Dac).cancel_plus(nd2di(1.0, 5.0, D::Trv)), nd2di(-0.09999999999999964, 0.09999999999999998, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Dac).cancel_plus(nd2di(1.0, 5.0, D::Com)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(-10.1, 5.0, D::Dac).cancel_plus(nd2di(-5.0, 10.0, D::Dac)), nd2di(-0.09999999999999964, 0.0, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.1, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Def)), nd2di(0.0, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(-10.1, 5.1, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Trv)), nd2di(-0.09999999999999964, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Com)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(0.9, 5.0, D::Trv).cancel_plus(nd2di(-5.0, -1.0, D::Dac)), nd2di(-0.09999999999999998, 0.0, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.1, D::Trv).cancel_plus(nd2di(-5.0, -1.0, D::Def)), nd2di(0.0, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(0.0, 5.1, D::Trv).cancel_plus(nd2di(-5.0, -0.0, D::Trv)), nd2di(0.0, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(0.9, 5.1, D::Com).cancel_plus(nd2di(-5.0, -1.0, D::Com)), nd2di(-0.09999999999999998, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Dac).cancel_plus(nd2di(-5.0, -1.0, D::Dac)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(0.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, -0.0, D::Trv)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(1.9999999999999964, 1.9999999999999964, D::Com).cancel_plus(nd2di(-0.1, -0.1, D::Com)), nd2di(1.8999999999999964, 1.8999999999999966, D::Trv));
-    assert_eq2!(nd2di(-0.1, 1.9999999999999964, D::Dac).cancel_plus(nd2di(-0.1, 0.01, D::Com)), nd2di(-0.09000000000000001, 1.8999999999999966, D::Trv));
-    assert_eq2!(nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(1.7976931348623157e+308, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Dac).cancel_plus(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com)), nd2di(0.0, 1.99584030953472e+292, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Dac).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com)), nd2di(-1.99584030953472e+292, 0.0, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 2.2204460492503128e-16, D::Dac).cancel_plus(nd2di(-1.0, 2.2204460492503126e-16, D::Com)), nd2di(-0.9999999999999999, -0.9999999999999998, D::Trv));
-    assert_eq2!(nd2di(-1.0, 2.2204460492503126e-16, D::Def).cancel_plus(nd2di(-1.0, 2.2204460492503128e-16, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(
+        nd2di(-5.1, -0.0, D::Com).cancel_plus(nd2di(0.0, 5.0, D::Com)),
+        nd2di(-0.09999999999999964, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.1, -1.0, D::Com).cancel_plus(nd2di(1.0, 5.0, D::Dac)),
+        nd2di(-0.09999999999999964, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -0.9, D::Com).cancel_plus(nd2di(1.0, 5.0, D::Def)),
+        nd2di(0.0, 0.09999999999999998, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.1, -0.9, D::Dac).cancel_plus(nd2di(1.0, 5.0, D::Trv)),
+        nd2di(-0.09999999999999964, 0.09999999999999998, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Dac).cancel_plus(nd2di(1.0, 5.0, D::Com)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.1, 5.0, D::Dac).cancel_plus(nd2di(-5.0, 10.0, D::Dac)),
+        nd2di(-0.09999999999999964, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.1, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Def)),
+        nd2di(0.0, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.1, 5.1, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Trv)),
+        nd2di(-0.09999999999999964, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, 10.0, D::Com)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(0.9, 5.0, D::Trv).cancel_plus(nd2di(-5.0, -1.0, D::Dac)),
+        nd2di(-0.09999999999999998, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.1, D::Trv).cancel_plus(nd2di(-5.0, -1.0, D::Def)),
+        nd2di(0.0, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(0.0, 5.1, D::Trv).cancel_plus(nd2di(-5.0, -0.0, D::Trv)),
+        nd2di(0.0, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(0.9, 5.1, D::Com).cancel_plus(nd2di(-5.0, -1.0, D::Com)),
+        nd2di(-0.09999999999999998, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Dac).cancel_plus(nd2di(-5.0, -1.0, D::Dac)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(0.0, 5.0, D::Def).cancel_plus(nd2di(-5.0, -0.0, D::Trv)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.9999999999999964, 1.9999999999999964, D::Com).cancel_plus(nd2di(
+            -0.1,
+            -0.1,
+            D::Com
+        )),
+        nd2di(1.8999999999999964, 1.8999999999999966, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-0.1, 1.9999999999999964, D::Dac).cancel_plus(nd2di(-0.1, 0.01, D::Com)),
+        nd2di(-0.09000000000000001, 1.8999999999999966, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(
+            1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(1.7976931348623157e+308, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Dac).cancel_plus(nd2di(
+            -1.7976931348623155e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(0.0, 1.99584030953472e+292, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Dac).cancel_plus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623155e+308,
+            D::Com
+        )),
+        nd2di(-1.99584030953472e+292, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com).cancel_plus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com).cancel_plus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 2.2204460492503128e-16, D::Dac).cancel_plus(nd2di(
+            -1.0,
+            2.2204460492503126e-16,
+            D::Com
+        )),
+        nd2di(-0.9999999999999999, -0.9999999999999998, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 2.2204460492503126e-16, D::Def).cancel_plus(nd2di(
+            -1.0,
+            2.2204460492503128e-16,
+            D::Com
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
 }
 
 #[test]
 fn minimal_cancel_minus_test() {
-    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_minus(I::EMPTY), I::ENTIRE);
+    assert_eq2!(
+        n2i(f64::NEG_INFINITY, -1.0).cancel_minus(I::EMPTY),
+        I::ENTIRE
+    );
     assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_minus(I::EMPTY), I::ENTIRE);
     assert_eq2!(I::ENTIRE.cancel_minus(I::EMPTY), I::ENTIRE);
-    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_minus(n2i(-1.0, 5.0)), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_minus(n2i(-1.0, 5.0)), I::ENTIRE);
+    assert_eq2!(
+        n2i(f64::NEG_INFINITY, -1.0).cancel_minus(n2i(-1.0, 5.0)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.0, f64::INFINITY).cancel_minus(n2i(-1.0, 5.0)),
+        I::ENTIRE
+    );
     assert_eq2!(I::ENTIRE.cancel_minus(n2i(-1.0, 5.0)), I::ENTIRE);
-    assert_eq2!(n2i(f64::NEG_INFINITY, -1.0).cancel_minus(I::ENTIRE), I::ENTIRE);
+    assert_eq2!(
+        n2i(f64::NEG_INFINITY, -1.0).cancel_minus(I::ENTIRE),
+        I::ENTIRE
+    );
     assert_eq2!(n2i(-1.0, f64::INFINITY).cancel_minus(I::ENTIRE), I::ENTIRE);
-    assert_eq2!(I::EMPTY.cancel_minus(n2i(f64::NEG_INFINITY, -1.0)), I::ENTIRE);
+    assert_eq2!(
+        I::EMPTY.cancel_minus(n2i(f64::NEG_INFINITY, -1.0)),
+        I::ENTIRE
+    );
     assert_eq2!(I::EMPTY.cancel_minus(n2i(-1.0, f64::INFINITY)), I::ENTIRE);
     assert_eq2!(I::EMPTY.cancel_minus(I::ENTIRE), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, 5.0).cancel_minus(n2i(f64::NEG_INFINITY, -1.0)), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, 5.0).cancel_minus(n2i(-1.0, f64::INFINITY)), I::ENTIRE);
+    assert_eq2!(
+        n2i(-1.0, 5.0).cancel_minus(n2i(f64::NEG_INFINITY, -1.0)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.0, 5.0).cancel_minus(n2i(-1.0, f64::INFINITY)),
+        I::ENTIRE
+    );
     assert_eq2!(n2i(-1.0, 5.0).cancel_minus(I::ENTIRE), I::ENTIRE);
-    assert_eq2!(I::ENTIRE.cancel_minus(n2i(f64::NEG_INFINITY, -1.0)), I::ENTIRE);
+    assert_eq2!(
+        I::ENTIRE.cancel_minus(n2i(f64::NEG_INFINITY, -1.0)),
+        I::ENTIRE
+    );
     assert_eq2!(I::ENTIRE.cancel_minus(n2i(-1.0, f64::INFINITY)), I::ENTIRE);
     assert_eq2!(I::ENTIRE.cancel_minus(I::ENTIRE), I::ENTIRE);
     assert_eq2!(n2i(-5.0, -1.0).cancel_minus(n2i(-5.1, -1.0)), I::ENTIRE);
@@ -190,101 +521,424 @@ fn minimal_cancel_minus_test() {
     assert_eq2!(I::EMPTY.cancel_minus(n2i(-10.0, -1.0)), I::EMPTY);
     assert_eq2!(I::EMPTY.cancel_minus(n2i(-10.0, 5.0)), I::EMPTY);
     assert_eq2!(I::EMPTY.cancel_minus(n2i(1.0, 5.0)), I::EMPTY);
-    assert_eq2!(n2i(-5.1, -0.0).cancel_minus(n2i(-5.0, 0.0)), n2i(-0.09999999999999964, 0.0));
-    assert_eq2!(n2i(-5.1, -1.0).cancel_minus(n2i(-5.0, -1.0)), n2i(-0.09999999999999964, 0.0));
-    assert_eq2!(n2i(-5.0, -0.9).cancel_minus(n2i(-5.0, -1.0)), n2i(0.0, 0.09999999999999998));
-    assert_eq2!(n2i(-5.1, -0.9).cancel_minus(n2i(-5.0, -1.0)), n2i(-0.09999999999999964, 0.09999999999999998));
+    assert_eq2!(
+        n2i(-5.1, -0.0).cancel_minus(n2i(-5.0, 0.0)),
+        n2i(-0.09999999999999964, 0.0)
+    );
+    assert_eq2!(
+        n2i(-5.1, -1.0).cancel_minus(n2i(-5.0, -1.0)),
+        n2i(-0.09999999999999964, 0.0)
+    );
+    assert_eq2!(
+        n2i(-5.0, -0.9).cancel_minus(n2i(-5.0, -1.0)),
+        n2i(0.0, 0.09999999999999998)
+    );
+    assert_eq2!(
+        n2i(-5.1, -0.9).cancel_minus(n2i(-5.0, -1.0)),
+        n2i(-0.09999999999999964, 0.09999999999999998)
+    );
     assert_eq2!(n2i(-5.0, -1.0).cancel_minus(n2i(-5.0, -1.0)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(-10.1, 5.0).cancel_minus(n2i(-10.0, 5.0)), n2i(-0.09999999999999964, 0.0));
-    assert_eq2!(n2i(-10.0, 5.1).cancel_minus(n2i(-10.0, 5.0)), n2i(0.0, 0.09999999999999964));
-    assert_eq2!(n2i(-10.1, 5.1).cancel_minus(n2i(-10.0, 5.0)), n2i(-0.09999999999999964, 0.09999999999999964));
+    assert_eq2!(
+        n2i(-10.1, 5.0).cancel_minus(n2i(-10.0, 5.0)),
+        n2i(-0.09999999999999964, 0.0)
+    );
+    assert_eq2!(
+        n2i(-10.0, 5.1).cancel_minus(n2i(-10.0, 5.0)),
+        n2i(0.0, 0.09999999999999964)
+    );
+    assert_eq2!(
+        n2i(-10.1, 5.1).cancel_minus(n2i(-10.0, 5.0)),
+        n2i(-0.09999999999999964, 0.09999999999999964)
+    );
     assert_eq2!(n2i(-10.0, 5.0).cancel_minus(n2i(-10.0, 5.0)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(0.9, 5.0).cancel_minus(n2i(1.0, 5.0)), n2i(-0.09999999999999998, 0.0));
-    assert_eq2!(n2i(-0.0, 5.1).cancel_minus(n2i(0.0, 5.0)), n2i(0.0, 0.09999999999999964));
-    assert_eq2!(n2i(1.0, 5.1).cancel_minus(n2i(1.0, 5.0)), n2i(0.0, 0.09999999999999964));
-    assert_eq2!(n2i(0.9, 5.1).cancel_minus(n2i(1.0, 5.0)), n2i(-0.09999999999999998, 0.09999999999999964));
+    assert_eq2!(
+        n2i(0.9, 5.0).cancel_minus(n2i(1.0, 5.0)),
+        n2i(-0.09999999999999998, 0.0)
+    );
+    assert_eq2!(
+        n2i(-0.0, 5.1).cancel_minus(n2i(0.0, 5.0)),
+        n2i(0.0, 0.09999999999999964)
+    );
+    assert_eq2!(
+        n2i(1.0, 5.1).cancel_minus(n2i(1.0, 5.0)),
+        n2i(0.0, 0.09999999999999964)
+    );
+    assert_eq2!(
+        n2i(0.9, 5.1).cancel_minus(n2i(1.0, 5.0)),
+        n2i(-0.09999999999999998, 0.09999999999999964)
+    );
     assert_eq2!(n2i(1.0, 5.0).cancel_minus(n2i(1.0, 5.0)), n2i(0.0, 0.0));
     assert_eq2!(n2i(-5.0, 1.0).cancel_minus(n2i(-1.0, 5.0)), n2i(-4.0, -4.0));
     assert_eq2!(n2i(-5.0, 0.0).cancel_minus(n2i(-0.0, 5.0)), n2i(-5.0, -5.0));
-    assert_eq2!(n2i(1.9999999999999964, 1.9999999999999964).cancel_minus(n2i(0.1, 0.1)), n2i(1.8999999999999964, 1.8999999999999966));
-    assert_eq2!(n2i(-0.1, 1.9999999999999964).cancel_minus(n2i(-0.01, 0.1)), n2i(-0.09000000000000001, 1.8999999999999966));
-    assert_eq2!(n2i(1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, -1.7976931348623157e+308)), n2i(1.7976931348623157e+308, f64::INFINITY));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)), n2i(0.0, 1.99584030953472e+292));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)), n2i(-1.99584030953472e+292, 0.0));
-    assert_eq2!(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
-    assert_eq2!(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308).cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)), I::ENTIRE);
-    assert_eq2!(n2i(5e-324, 5e-324).cancel_minus(n2i(5e-324, 5e-324)), n2i(0.0, 0.0));
-    assert_eq2!(n2i(5e-324, 5e-324).cancel_minus(n2i(-5e-324, -5e-324)), n2i(1e-323, 1e-323));
-    assert_eq2!(n2i(2.2250738585072014e-308, 2.2250738585072024e-308).cancel_minus(n2i(2.2250738585072014e-308, 2.225073858507202e-308)), n2i(0.0, 5e-324));
-    assert_eq2!(n2i(2.2250738585072014e-308, 2.225073858507202e-308).cancel_minus(n2i(2.2250738585072014e-308, 2.2250738585072024e-308)), I::ENTIRE);
-    assert_eq2!(n2i(-1.0, 2.2204460492503128e-16).cancel_minus(n2i(-2.2204460492503126e-16, 1.0)), n2i(-0.9999999999999999, -0.9999999999999998));
-    assert_eq2!(n2i(-1.0, 2.2204460492503126e-16).cancel_minus(n2i(-2.2204460492503128e-16, 1.0)), I::ENTIRE);
+    assert_eq2!(
+        n2i(1.9999999999999964, 1.9999999999999964).cancel_minus(n2i(0.1, 0.1)),
+        n2i(1.8999999999999964, 1.8999999999999966)
+    );
+    assert_eq2!(
+        n2i(-0.1, 1.9999999999999964).cancel_minus(n2i(-0.01, 0.1)),
+        n2i(-0.09000000000000001, 1.8999999999999966)
+    );
+    assert_eq2!(
+        n2i(1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_minus(n2i(-1.7976931348623157e+308, -1.7976931348623157e+308)),
+        n2i(1.7976931348623157e+308, f64::INFINITY)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)),
+        n2i(0.0, 0.0)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)),
+        n2i(0.0, 1.99584030953472e+292)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)
+            .cancel_minus(n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)),
+        n2i(-1.99584030953472e+292, 0.0)
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623157e+308, 1.7976931348623155e+308)
+            .cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.7976931348623155e+308, 1.7976931348623157e+308)
+            .cancel_minus(n2i(-1.7976931348623157e+308, 1.7976931348623157e+308)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(5e-324, 5e-324).cancel_minus(n2i(5e-324, 5e-324)),
+        n2i(0.0, 0.0)
+    );
+    assert_eq2!(
+        n2i(5e-324, 5e-324).cancel_minus(n2i(-5e-324, -5e-324)),
+        n2i(1e-323, 1e-323)
+    );
+    assert_eq2!(
+        n2i(2.2250738585072014e-308, 2.2250738585072024e-308)
+            .cancel_minus(n2i(2.2250738585072014e-308, 2.225073858507202e-308)),
+        n2i(0.0, 5e-324)
+    );
+    assert_eq2!(
+        n2i(2.2250738585072014e-308, 2.225073858507202e-308)
+            .cancel_minus(n2i(2.2250738585072014e-308, 2.2250738585072024e-308)),
+        I::ENTIRE
+    );
+    assert_eq2!(
+        n2i(-1.0, 2.2204460492503128e-16).cancel_minus(n2i(-2.2204460492503126e-16, 1.0)),
+        n2i(-0.9999999999999999, -0.9999999999999998)
+    );
+    assert_eq2!(
+        n2i(-1.0, 2.2204460492503126e-16).cancel_minus(n2i(-2.2204460492503128e-16, 1.0)),
+        I::ENTIRE
+    );
 }
 
 #[test]
 fn minimal_cancel_minus_dec_test() {
-    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Def).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Trv).cancel_minus(nd2di(-1.0, 5.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, 5.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, 5.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, -1.0, D::Def).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, f64::INFINITY, D::Trv).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(-1.0, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 5.0, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 5.0, D::Def).cancel_minus(nd2di(-1.0, f64::INFINITY, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 5.0, D::Com).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Com).cancel_minus(nd2di(-5.1, -1.0, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Dac).cancel_minus(nd2di(-5.0, -0.9, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Def).cancel_minus(nd2di(-5.1, -0.9, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Trv).cancel_minus(nd2di(-10.1, 5.0, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Com).cancel_minus(nd2di(-10.0, 5.1, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Dac).cancel_minus(nd2di(-10.1, 5.1, D::Trv)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Def).cancel_minus(nd2di(0.9, 5.0, D::Def)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Trv).cancel_minus(nd2di(1.0, 5.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Com).cancel_minus(nd2di(0.9, 5.1, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, -1.0, D::Com).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Dac).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Def).cancel_minus(DI::EMPTY), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, -1.0, D::Dac).cancel_minus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, f64::INFINITY, D::Def).cancel_minus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, -1.0, D::Trv).cancel_minus(nd2di(-1.0, 5.0, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, 5.0, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(-1.0, 5.0, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, -1.0, D::Def).cancel_minus(nd2di(
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, f64::INFINITY, D::Trv).cancel_minus(nd2di(
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        DI::EMPTY.cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        DI::EMPTY.cancel_minus(nd2di(-1.0, f64::INFINITY, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        DI::EMPTY.cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 5.0, D::Dac).cancel_minus(nd2di(f64::NEG_INFINITY, -1.0, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 5.0, D::Def).cancel_minus(nd2di(-1.0, f64::INFINITY, D::Trv)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 5.0, D::Com).cancel_minus(nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(
+            f64::NEG_INFINITY,
+            -1.0,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(
+            -1.0,
+            f64::INFINITY,
+            D::Def
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Dac).cancel_minus(nd2di(
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+            D::Def
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Com).cancel_minus(nd2di(-5.1, -1.0, D::Trv)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Dac).cancel_minus(nd2di(-5.0, -0.9, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Def).cancel_minus(nd2di(-5.1, -0.9, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Trv).cancel_minus(nd2di(-10.1, 5.0, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Com).cancel_minus(nd2di(-10.0, 5.1, D::Com)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Dac).cancel_minus(nd2di(-10.1, 5.1, D::Trv)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Def).cancel_minus(nd2di(0.9, 5.0, D::Def)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Trv).cancel_minus(nd2di(1.0, 5.1, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Com).cancel_minus(nd2di(0.9, 5.1, D::Dac)),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, -1.0, D::Com).cancel_minus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Dac).cancel_minus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Def).cancel_minus(DI::EMPTY),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
     assert_eq2!(DI::EMPTY.cancel_minus(DI::EMPTY), DI::EMPTY);
-    assert_eq2!(DI::EMPTY.cancel_minus(nd2di(-10.0, -1.0, D::Com)), DI::EMPTY);
+    assert_eq2!(
+        DI::EMPTY.cancel_minus(nd2di(-10.0, -1.0, D::Com)),
+        DI::EMPTY
+    );
     assert_eq2!(DI::EMPTY.cancel_minus(nd2di(-10.0, 5.0, D::Dac)), DI::EMPTY);
     assert_eq2!(DI::EMPTY.cancel_minus(nd2di(1.0, 5.0, D::Def)), DI::EMPTY);
-    assert_eq2!(nd2di(-5.1, -0.0, D::Com).cancel_minus(nd2di(-5.0, 0.0, D::Com)), nd2di(-0.09999999999999964, 0.0, D::Trv));
-    assert_eq2!(nd2di(-5.1, -1.0, D::Dac).cancel_minus(nd2di(-5.0, -1.0, D::Com)), nd2di(-0.09999999999999964, 0.0, D::Trv));
-    assert_eq2!(nd2di(-5.0, -0.9, D::Def).cancel_minus(nd2di(-5.0, -1.0, D::Com)), nd2di(0.0, 0.09999999999999998, D::Trv));
-    assert_eq2!(nd2di(-5.1, -0.9, D::Trv).cancel_minus(nd2di(-5.0, -1.0, D::Com)), nd2di(-0.09999999999999964, 0.09999999999999998, D::Trv));
-    assert_eq2!(nd2di(-5.0, -1.0, D::Com).cancel_minus(nd2di(-5.0, -1.0, D::Dac)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(-10.1, 5.0, D::Dac).cancel_minus(nd2di(-10.0, 5.0, D::Dac)), nd2di(-0.09999999999999964, 0.0, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.1, D::Def).cancel_minus(nd2di(-10.0, 5.0, D::Dac)), nd2di(0.0, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(-10.1, 5.1, D::Trv).cancel_minus(nd2di(-10.0, 5.0, D::Def)), nd2di(-0.09999999999999964, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(-10.0, 5.0, D::Com).cancel_minus(nd2di(-10.0, 5.0, D::Def)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(0.9, 5.0, D::Dac).cancel_minus(nd2di(1.0, 5.0, D::Def)), nd2di(-0.09999999999999998, 0.0, D::Trv));
-    assert_eq2!(nd2di(-0.0, 5.1, D::Def).cancel_minus(nd2di(0.0, 5.0, D::Def)), nd2di(0.0, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.1, D::Trv).cancel_minus(nd2di(1.0, 5.0, D::Trv)), nd2di(0.0, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(0.9, 5.1, D::Com).cancel_minus(nd2di(1.0, 5.0, D::Trv)), nd2di(-0.09999999999999998, 0.09999999999999964, D::Trv));
-    assert_eq2!(nd2di(1.0, 5.0, D::Dac).cancel_minus(nd2di(1.0, 5.0, D::Com)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(-5.0, 1.0, D::Def).cancel_minus(nd2di(-1.0, 5.0, D::Def)), nd2di(-4.0, -4.0, D::Trv));
-    assert_eq2!(nd2di(-5.0, 0.0, D::Trv).cancel_minus(nd2di(-0.0, 5.0, D::Trv)), nd2di(-5.0, -5.0, D::Trv));
-    assert_eq2!(nd2di(1.9999999999999964, 1.9999999999999964, D::Com).cancel_minus(nd2di(0.1, 0.1, D::Com)), nd2di(1.8999999999999964, 1.8999999999999966, D::Trv));
-    assert_eq2!(nd2di(-0.1, 1.9999999999999964, D::Def).cancel_minus(nd2di(-0.01, 0.1, D::Dac)), nd2di(-0.09000000000000001, 1.8999999999999966, D::Trv));
-    assert_eq2!(nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, -1.7976931348623157e+308, D::Com)), nd2di(1.7976931348623157e+308, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com)), nd2di(0.0, 1.99584030953472e+292, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com)), nd2di(-1.99584030953472e+292, 0.0, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(5e-324, 5e-324, D::Com).cancel_minus(nd2di(5e-324, 5e-324, D::Com)), nd2di(0.0, 0.0, D::Trv));
-    assert_eq2!(nd2di(5e-324, 5e-324, D::Com).cancel_minus(nd2di(-5e-324, -5e-324, D::Dac)), nd2di(1e-323, 1e-323, D::Trv));
-    assert_eq2!(nd2di(2.2250738585072014e-308, 2.2250738585072024e-308, D::Dac).cancel_minus(nd2di(2.2250738585072014e-308, 2.225073858507202e-308, D::Dac)), nd2di(0.0, 5e-324, D::Trv));
-    assert_eq2!(nd2di(2.2250738585072014e-308, 2.225073858507202e-308, D::Def).cancel_minus(nd2di(2.2250738585072014e-308, 2.2250738585072024e-308, D::Com)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
-    assert_eq2!(nd2di(-1.0, 2.2204460492503128e-16, D::Com).cancel_minus(nd2di(-2.2204460492503126e-16, 1.0, D::Dac)), nd2di(-0.9999999999999999, -0.9999999999999998, D::Trv));
-    assert_eq2!(nd2di(-1.0, 2.2204460492503126e-16, D::Def).cancel_minus(nd2di(-2.2204460492503128e-16, 1.0, D::Dac)), nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv));
+    assert_eq2!(
+        nd2di(-5.1, -0.0, D::Com).cancel_minus(nd2di(-5.0, 0.0, D::Com)),
+        nd2di(-0.09999999999999964, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.1, -1.0, D::Dac).cancel_minus(nd2di(-5.0, -1.0, D::Com)),
+        nd2di(-0.09999999999999964, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -0.9, D::Def).cancel_minus(nd2di(-5.0, -1.0, D::Com)),
+        nd2di(0.0, 0.09999999999999998, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.1, -0.9, D::Trv).cancel_minus(nd2di(-5.0, -1.0, D::Com)),
+        nd2di(-0.09999999999999964, 0.09999999999999998, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, -1.0, D::Com).cancel_minus(nd2di(-5.0, -1.0, D::Dac)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.1, 5.0, D::Dac).cancel_minus(nd2di(-10.0, 5.0, D::Dac)),
+        nd2di(-0.09999999999999964, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.1, D::Def).cancel_minus(nd2di(-10.0, 5.0, D::Dac)),
+        nd2di(0.0, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.1, 5.1, D::Trv).cancel_minus(nd2di(-10.0, 5.0, D::Def)),
+        nd2di(-0.09999999999999964, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-10.0, 5.0, D::Com).cancel_minus(nd2di(-10.0, 5.0, D::Def)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(0.9, 5.0, D::Dac).cancel_minus(nd2di(1.0, 5.0, D::Def)),
+        nd2di(-0.09999999999999998, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-0.0, 5.1, D::Def).cancel_minus(nd2di(0.0, 5.0, D::Def)),
+        nd2di(0.0, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.1, D::Trv).cancel_minus(nd2di(1.0, 5.0, D::Trv)),
+        nd2di(0.0, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(0.9, 5.1, D::Com).cancel_minus(nd2di(1.0, 5.0, D::Trv)),
+        nd2di(-0.09999999999999998, 0.09999999999999964, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.0, 5.0, D::Dac).cancel_minus(nd2di(1.0, 5.0, D::Com)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, 1.0, D::Def).cancel_minus(nd2di(-1.0, 5.0, D::Def)),
+        nd2di(-4.0, -4.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-5.0, 0.0, D::Trv).cancel_minus(nd2di(-0.0, 5.0, D::Trv)),
+        nd2di(-5.0, -5.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.9999999999999964, 1.9999999999999964, D::Com).cancel_minus(nd2di(0.1, 0.1, D::Com)),
+        nd2di(1.8999999999999964, 1.8999999999999966, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-0.1, 1.9999999999999964, D::Def).cancel_minus(nd2di(-0.01, 0.1, D::Dac)),
+        nd2di(-0.09000000000000001, 1.8999999999999966, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(
+            -1.7976931348623157e+308,
+            -1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(1.7976931348623157e+308, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623155e+308,
+            D::Com
+        )),
+        nd2di(0.0, 1.99584030953472e+292, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(
+            -1.7976931348623155e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(-1.99584030953472e+292, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623157e+308, 1.7976931348623155e+308, D::Com).cancel_minus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.7976931348623155e+308, 1.7976931348623157e+308, D::Com).cancel_minus(nd2di(
+            -1.7976931348623157e+308,
+            1.7976931348623157e+308,
+            D::Com
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(5e-324, 5e-324, D::Com).cancel_minus(nd2di(5e-324, 5e-324, D::Com)),
+        nd2di(0.0, 0.0, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(5e-324, 5e-324, D::Com).cancel_minus(nd2di(-5e-324, -5e-324, D::Dac)),
+        nd2di(1e-323, 1e-323, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(2.2250738585072014e-308, 2.2250738585072024e-308, D::Dac).cancel_minus(nd2di(
+            2.2250738585072014e-308,
+            2.225073858507202e-308,
+            D::Dac
+        )),
+        nd2di(0.0, 5e-324, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(2.2250738585072014e-308, 2.225073858507202e-308, D::Def).cancel_minus(nd2di(
+            2.2250738585072014e-308,
+            2.2250738585072024e-308,
+            D::Com
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 2.2204460492503128e-16, D::Com).cancel_minus(nd2di(
+            -2.2204460492503126e-16,
+            1.0,
+            D::Dac
+        )),
+        nd2di(-0.9999999999999999, -0.9999999999999998, D::Trv)
+    );
+    assert_eq2!(
+        nd2di(-1.0, 2.2204460492503126e-16, D::Def).cancel_minus(nd2di(
+            -2.2204460492503128e-16,
+            1.0,
+            D::Dac
+        )),
+        nd2di(f64::NEG_INFINITY, f64::INFINITY, D::Trv)
+    );
 }


### PR DESCRIPTION
Implement `cancel_minus` and `cancel_plus`.  It passes the tests (at least on `x86_64`).  Maybe there is a better implementation but at least it is a basis for discussion.

Depends on https://github.com/unageek/ITF1788/pull/1